### PR TITLE
add `substrate-rpc-primitives` to use `NumberOrHex` in rpc.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 sr-version = { git = "https://github.com/paritytech/substrate/", package = "sr-version" }
 srml-system = { git = "https://github.com/paritytech/substrate/", package = "srml-system" }
 substrate-rpc-api = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-api" }
+substrate-rpc-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-primitives" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }
 transaction_pool = { git = "https://github.com/paritytech/substrate/", package = "substrate-transaction-pool" }
 url = "1.7"

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -44,12 +44,10 @@ use std::convert::TryInto;
 use substrate_primitives::storage::StorageKey;
 use substrate_rpc_api::{
     author::AuthorClient,
-    chain::{
-        number::NumberOrHex,
-        ChainClient,
-    },
+    chain::ChainClient,
     state::StateClient,
 };
+use substrate_rpc_primitives::number::NumberOrHex;
 
 pub type ChainBlock<T> = SignedBlock<Block<<T as System>::Header, OpaqueExtrinsic>>;
 pub type BlockNumber<T> = NumberOrHex<<T as System>::BlockNumber>;


### PR DESCRIPTION
Was moved from chain::number::NumberOrHex to substrate_rpc_primitives::number::NumberOrHex changed recently in https://github.com/paritytech/substrate/pull/3563