### PR TITLE
Opaque events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ url = "1.7"
 env_logger = "0.6"
 node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime" }
 srml-balances = { git = "https://github.com/paritytech/substrate/", package = "srml-balances" }
+srml-contracts = { git = "https://github.com/paritytech/substrate/", package = "srml-contracts" }
 substrate-keyring = { git = "https://github.com/paritytech/substrate/", package = "substrate-keyring" }
 tokio = "0.1"
 wabt = "0.9.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::metadata::MetadataError;
+use crate::{
+    events::EventsError,
+    metadata::MetadataError,
+};
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
 use std::io::Error as IoError;
@@ -25,6 +28,8 @@ use substrate_primitives::crypto::SecretStringError;
 pub enum Error {
     /// Codec error.
     Codec(CodecError),
+    /// Events error.
+    Events(EventsError),
     /// Io error.
     Io(IoError),
     /// Rpc error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ use std::io::Error as IoError;
 use substrate_primitives::crypto::SecretStringError;
 
 /// Error enum.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, derive_more::From, derive_more::Display)]
 pub enum Error {
     /// Codec error.
     Codec(CodecError),
@@ -35,6 +35,7 @@ pub enum Error {
     /// Rpc error.
     Rpc(RpcError),
     /// Secret string error.
+    #[display(fmt = "Secret String Error")]
     SecretString(SecretStringError),
     /// Metadata error.
     Metadata(MetadataError),

--- a/src/events.rs
+++ b/src/events.rs
@@ -45,16 +45,21 @@ use std::{
 };
 use std::collections::HashSet;
 
+/// Top level Event that can be produced by a substrate runtime
 #[derive(Debug)]
 pub enum RuntimeEvent {
     System(SystemEvent),
     Raw(RawEvent),
 }
 
+/// Raw bytes for an Event
 #[derive(Debug)]
 pub struct RawEvent {
+    /// The name of the module from whence the Event originated
     pub module: String,
+    /// The name of the Event
     pub variant: String,
+    /// The raw Event data
     pub data: Vec<u8>,
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -14,14 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-//! A library to **sub**mit e**xt**rinsics to a
-//! [substrate](https://github.com/paritytech/substrate) node via RPC.
-
-#![deny(missing_docs)]
-#![deny(warnings)]
-
-use parity_scale_codec::{Decode, Compact, Error as CodecError};
-use crate::{System, Error, metadata::Metadata};
+use parity_scale_codec::{Codec, Decode, Compact, Error as CodecError, Input, Output, Encode};
+use crate::{System, Error, metadata::{Metadata, EventArg}};
 
 use runtime_primitives::traits::Hash;
 use substrate_primitives::storage::StorageChangeSet;
@@ -34,132 +28,112 @@ use futures::future::{
 };
 use futures::stream::Stream;
 use srml_system::{Phase};
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::marker::{Send, PhantomData};
+use std::fs::metadata;
+use crate::metadata::{MetadataError, EventArg};
+use crate::srml::balances::Balances;
+use std::convert::TryFrom;
 
-/// Captures data for when an extrinsic is successfully included in a block
-#[derive(Debug)]
-pub struct ExtrinsicSuccess<T: System> {
-    /// Block hash.
-    pub block: T::Hash,
-    /// Extrinsic hash.
-    pub extrinsic: T::Hash,
-    /// Events by module and variant.
-    events: HashMap<String, Vec<Box<dyn Any + Send>>>,
+pub struct RawEvent {
+    module: String,
+    variant: String,
+    data: Vec<u8>,
 }
 
-impl<T: System> ExtrinsicSuccess<T> {
-    /// Get all events for a module, attempting to decode them.
-    /// Returns an empty iterator if no events for that module.
-    /// Returns an error if any of the events fail to downcast to the given Event type.
-    pub fn module_events<E>(&self, module: &str) -> Result<Vec<E>, Error> where E: Decode + Clone + 'static {
-        self.events
-            .get(&module.to_string())
-            .map_or(Ok(Vec::new()), |events| {
-                events
-                    .into_iter()
-                    .map(|event| {
-                        event.downcast_ref::<E>()
-                            .map(Clone::clone)
-                            .ok_or("Wrong Event type for module".into()) // todo: [AJ] err
-                    })
-                    .collect::<Result<Vec<E>, _>>()
-            })
-    }
-}
-
-pub struct EventListener<T> {
+pub struct EventsDecoder<T> {
     metadata: Metadata, // todo: borrow?
-    decoders: HashMap<String, fn(&mut &[u8]) -> Result<Box<dyn Any + Send + 'static>, CodecError>>,
+    type_sizes: HashMap<String, usize>,
     marker: PhantomData<fn() -> T>,
 }
 
-impl<T: System + 'static> EventListener<T> {
-    pub fn new(metadata: Metadata) -> Self {
-        Self { metadata, decoders: HashMap::new(), marker: PhantomData }
+#[derive(Debug, derive_more::From)]
+pub enum EventError {
+    CodecError(CodecError),
+    Metadata(MetadataError),
+    TypeSizesMissing(String, String),
+    TypeSizeUnavailable(String),
+}
+
+impl<T: System + Balances + 'static> TryFrom<Metadata> for EventsDecoder<T> {
+    type Error = EventError;
+
+    fn try_from(value: Metadata) -> Result<Self, Self::Error> {
+        let mut listener = Self { metadata, type_sizes: HashMap::new(), marker: PhantomData };
+        listener.register_type_size::<T::Hash>("Hash")?;
+        listener.register_type_size::<<T as Balances>::Balance>("Balance")?;
+        listener.check_all_event_types()?;
+        listener
+    }
+}
+
+impl<T: System + Balances + 'static> EventsDecoder<T> {
+    pub fn register_type_size<U>(&mut self, name: &str) -> Result<usize, EventError> where U: Default + Codec + Send + 'static {
+        let size = U::default().size_hint();
+        if size > 0 {
+            self.type_sizes.insert(name.to_string(), size);
+            Ok(size)
+        } else {
+            Err(EventError::TypeSizeUnavailable(name.to_owned()))
+        }
     }
 
-    pub fn register_module_event_decoder<Event>(&mut self, module: &str) where Event: Decode + Send + 'static {
-        self.decoders.insert(module.to_string(), |input| {
-            Decode::decode(input).map(|evt: Event| Box::new(evt) as Box<dyn Any + Send>)
-        });
-    }
-
-    /// Dynamically decode `Vec<EventRecord<T>>` by resolving a decoder for the module Event variant
-    fn decode_events(&self, input: &mut &[u8]) -> Result<Vec<(Phase, String, Box<dyn Any + Send + 'static>)>, Error> {
-        <Compact<u32>>::decode(input)
-            .map_err(Into::into)
-            .and_then(move |Compact(len)| {
-                let len = len as usize;
-                let mut r = Vec::new();
-                for _ in 0..len {
-                    let phase = Phase::decode(input)?;
-                    let module_variant = u8::decode(input)?;
-                    let module = self.metadata.module_name(module_variant)?;
-                    println!("phase {:?}, variant {:?}, module {:?}", phase, module_variant, module);
-                    let event_decoder = self.decoders.get(&module).unwrap(); // todo: [AJ]
-//                        .ok_or(format!("No Event Decoder registered for '{}'", module).into())?;
-                    let event = event_decoder(input).unwrap();
-                    let _topics = Vec::<T::Hash>::decode(input)?;
-                    r.push((phase, module, event));
+    fn decode_raw_bytes<I: Input, W: Output>(&self, args: &[EventArg], input: &mut I, output: &mut W) -> Result<(), EventError> {
+        for arg in args {
+            match arg {
+                EventArg::Vec(arg) => {
+                    let len = <Compact<u32>>::decode(input)?;
+                    len.encode_to(output);
+                    for _ in 0..len {
+                        self.decode_raw_bytes(arg, input, output)?
+                    }
+                },
+                EventArg::Tuple(args) => {
+                    for arg in args {
+                        self.decode_raw_bytes(arg, input, output)?
+                    }
+                },
+                EventArg::Primitive(name) => {
+                    if let Some(size) = self.type_sizes.get(name) {
+                        let mut buf = [0u8; size];
+                        input.read(&mut buf[..])?;
+                        buf.encode_to(output)
+                    } else {
+                        Err(EventError::TypeSizeUnavailable(name.to_owned()))
+                    }
                 }
-                Ok(r)
-            })
+            }
+        }
+        Ok(())
     }
 
-    /// Waits for events for the block triggered by the extrinsic
-    pub fn wait_for_block_events(
-        self,
-        ext_hash: T::Hash,
-        signed_block: ChainBlock<T>,
-        block_hash: T::Hash,
-        events_stream: MapStream<StorageChangeSet<T::Hash>>,
-    ) -> impl Future<Item = ExtrinsicSuccess<T>, Error = Error> {
-        let ext_index = signed_block
-            .block
-            .extrinsics
-            .iter()
-            .position(|ext| {
-                let hash = T::Hashing::hash_of(ext);
-                hash == ext_hash
-            })
-            .ok_or(format!("Failed to find Extrinsic with hash {:?}", ext_hash).into())
-            .into_future();
+    pub fn decode_events(&self, input: &mut &[u8]) -> Result<Vec<(Phase, RawEvent)>, Error> {
+        let compact_len = <Compact<u32>>::decode(input)?;
+        let len = len.0 as usize;
 
-        let block_hash = block_hash.clone();
-        events_stream
-            .filter(move |event| event.block == block_hash)
-            .into_future()
-            .map_err(|(e, _)| e.into())
-            .join(ext_index)
-            .and_then(move |((change_set, _), ext_index)| {
-                let events =
-                    match change_set {
-                        None => HashMap::new(),
-                        Some(change_set) => {
-                            let mut events = HashMap::new();
-                            for (_key, data) in change_set.changes {
-                                if let Some(data) = data {
-                                    if let Ok(any_events) = self.decode_events(&mut &data.0[..]) {
-                                        for (phase, module, event) in any_events {
-                                            if let Phase::ApplyExtrinsic(i) = phase {
-                                                if i as usize == ext_index {
-                                                    let events = events.entry(module).or_insert(Vec::new());
-                                                    events.push(event)
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            events
-                        }
-                    };
-                future::ok(ExtrinsicSuccess {
-                    block: block_hash,
-                    extrinsic: ext_hash,
-                    events,
-                })
-            })
+        let mut r = Vec::new();
+        for _ in 0..len {
+            // decode EventRecord
+            let phase = Phase::decode(input)?;
+            let module_variant = u8::decode(input)?;
+            let event_variant = u8::decode(input)?;
+            let _topics = Vec::<T::Hash>::decode(input)?;
+
+            let module_name = self.metadata.module_name(module_variant)?;
+            let module = self.metadata.module(&module_name)?;
+            let event_metadata = module.event(event_variant)?;
+
+            let mut event_data = Vec::<u8>::new();
+            self.decode_raw_bytes(&event_metadata.arguments, input, event_data)?;
+            let raw_event = RawEvent {
+                module: module_name,
+                variant: event_metadata.name,
+                data: event_data,
+            };
+
+            println!("phase {:?}, module {:?}, event {:?}", phase, module_name, event_metadata.name);
+            r.push((phase, raw_event));
+        }
+        Ok(r)
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     srml::balances::Balances,
     System,
+    SystemEvent,
 };
 use parity_scale_codec::{
     Codec,
@@ -43,6 +44,12 @@ use std::{
     },
 };
 use std::collections::HashSet;
+
+#[derive(Debug)]
+pub enum RuntimeEvent {
+    System(SystemEvent),
+    Raw(RawEvent),
+}
 
 #[derive(Debug)]
 pub struct RawEvent {
@@ -176,7 +183,7 @@ impl<T: System + Balances + 'static> EventsDecoder<T> {
     pub fn decode_events(
         &self,
         input: &mut &[u8],
-    ) -> Result<Vec<(Phase, RawEvent)>, EventsError> {
+    ) -> Result<Vec<(Phase, RuntimeEvent)>, EventsError> {
         let compact_len = <Compact<u32>>::decode(input)?;
         let len = compact_len.0 as usize;
 
@@ -185,24 +192,30 @@ impl<T: System + Balances + 'static> EventsDecoder<T> {
             // decode EventRecord
             let phase = Phase::decode(input)?;
             let module_variant = input.read_byte()? as u8;
-            let event_variant = input.read_byte()? as u8;
 
             let module_name = self.metadata.module_name(module_variant)?;
-            let module = self.metadata.module(&module_name)?;
-            let event_metadata = module.event(event_variant)?;
-            log::debug!("decoding event '{}::{}'", module_name, event_metadata.name);
+            let event =
+                if module_name == "System" {
+                    let system_event = SystemEvent::decode(input)?;
+                    RuntimeEvent::System(system_event)
+                } else {
+                    let event_variant = input.read_byte()? as u8;
+                    let module = self.metadata.module(&module_name)?;
+                    let event_metadata = module.event(event_variant)?;
+                    log::debug!("decoding event '{}::{}'", module_name, event_metadata.name);
 
-            let mut event_data = Vec::<u8>::new();
-            self.decode_raw_bytes(&event_metadata.arguments(), input, &mut event_data)?;
+                    let mut event_data = Vec::<u8>::new();
+                    self.decode_raw_bytes(&event_metadata.arguments(), input, &mut event_data)?;
+                    RuntimeEvent::Raw(RawEvent {
+                        module: module_name.clone(),
+                        variant: event_metadata.name.clone(),
+                        data: event_data,
+                    })
+                };
+
             // topics come after the event data in EventRecord
             let _topics = Vec::<T::Hash>::decode(input)?;
-
-            let raw_event = RawEvent {
-                module: module_name.clone(),
-                variant: event_metadata.name.clone(),
-                data: event_data,
-            };
-            r.push((phase, raw_event));
+            r.push((phase, event));
         }
         Ok(r)
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -63,10 +63,11 @@ pub struct RawEvent {
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, derive_more::From, derive_more::Display)]
 pub enum EventsError {
     CodecError(CodecError),
     Metadata(MetadataError),
+    #[display(fmt = "Type Sizes Missing: {:?}", _0)]
     TypeSizesMissing(Vec<String>),
     TypeSizeUnavailable(String),
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -17,21 +17,17 @@
 use parity_scale_codec::{Codec, Decode, Compact, Error as CodecError, Input, Output, Encode};
 use crate::{System, Error, metadata::{Metadata, EventArg}};
 
-use runtime_primitives::traits::Hash;
-use substrate_primitives::storage::StorageChangeSet;
+
+
 use std::collections::HashMap;
-use crate::rpc::{ChainBlock, MapStream};
-use futures::future::{
-    self,
-    Future,
-    IntoFuture,
-};
-use futures::stream::Stream;
+
+
+
 use srml_system::{Phase};
-use std::any::{Any, TypeId};
+
 use std::marker::{Send, PhantomData};
 use std::fs::metadata;
-use crate::metadata::{MetadataError, EventArg};
+use crate::metadata::{MetadataError};
 use crate::srml::balances::Balances;
 use std::convert::TryFrom;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,161 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of substrate-subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A library to **sub**mit e**xt**rinsics to a
+//! [substrate](https://github.com/paritytech/substrate) node via RPC.
+
+#![deny(missing_docs)]
+#![deny(warnings)]
+
+use parity_scale_codec::{Decode, Compact, Error as CodecError};
+use crate::{System, Error, metadata::Metadata};
+
+use runtime_primitives::traits::Hash;
+use substrate_primitives::storage::StorageChangeSet;
+use std::collections::HashMap;
+use crate::rpc::{ChainBlock, MapStream};
+use futures::future::{
+    self,
+    Future,
+    IntoFuture,
+};
+use futures::stream::Stream;
+use srml_system::{Phase};
+use std::any::Any;
+use std::marker::Send;
+
+/// Captures data for when an extrinsic is successfully included in a block
+#[derive(Debug)]
+pub struct ExtrinsicSuccess<T: System> {
+    /// Block hash.
+    pub block: T::Hash,
+    /// Extrinsic hash.
+    pub extrinsic: T::Hash,
+    /// Events by module and variant.
+    events: HashMap<String, Vec<Box<dyn Any + Send>>>,
+}
+
+impl<T: System> ExtrinsicSuccess<T> {
+    /// Get all events for a module, attempting to decode them.
+    /// Returns an empty iterator if no events for that module.
+    /// Returns an error if any of the events fail to downcast to the given Event type.
+    pub fn module_events<E>(&self, module: &str) -> Result<Vec<E>, Error> where E: Decode + Clone + 'static {
+        self.events
+            .get(&module.to_string())
+            .map_or(Ok(Vec::new()), |events| {
+                events
+                    .into_iter()
+                    .map(|event| {
+                        event.downcast_ref::<E>()
+                            .map(Clone::clone)
+                            .ok_or("Wrong Event type for module".into()) // todo: [AJ] err
+                    })
+                    .collect::<Result<Vec<E>, _>>()
+            })
+    }
+}
+
+pub struct EventListener {
+    metadata: Metadata, // todo: borrow?
+    decoders: HashMap<String, fn(&mut &[u8]) -> Result<Box<dyn Any + Send + 'static>, CodecError>>,
+}
+
+impl EventListener {
+    pub fn new(metadata: Metadata) -> Self {
+        Self { metadata, decoders: HashMap::new(), }
+    }
+
+    pub fn register_module_event_decoder<Event>(&mut self, module: &str) where Event: Decode + Send + 'static {
+        self.decoders.insert(module.to_string(), |input| {
+            Decode::decode(input).map(|evt: Event| Box::new(evt) as Box<dyn Any + Send>)
+        });
+    }
+
+    fn decode_events(&self, input: &mut &[u8]) -> Result<Vec<(Phase, String, Box<dyn Any + Send + 'static>)>, Error> {
+        <Compact<u32>>::decode(input)
+            .map_err(Into::into)
+            .and_then(move |Compact(len)| {
+                let len = len as usize;
+                let mut r = Vec::new();
+                for _ in 0..len {
+                    let phase = Phase::decode(input)?;
+                    let module_variant = u8::decode(input)?;
+                    let module = self.metadata.module_name(module_variant)?;
+                    let event_decoder = self.decoders.get(&module).unwrap(); // todo: [AJ]
+//                        .ok_or(format!("No Event Decoder registered for '{}'", module).into())?;
+                    let event = event_decoder(input)?;
+                    r.push((phase, module, event));
+                }
+                Ok(r)
+            })
+    }
+
+    /// Waits for events for the block triggered by the extrinsic
+    pub fn wait_for_block_events<T: System + 'static>(
+        self,
+        ext_hash: T::Hash,
+        signed_block: ChainBlock<T>,
+        block_hash: T::Hash,
+        events_stream: MapStream<StorageChangeSet<T::Hash>>,
+    ) -> impl Future<Item = ExtrinsicSuccess<T>, Error = Error> {
+        let ext_index = signed_block
+            .block
+            .extrinsics
+            .iter()
+            .position(|ext| {
+                let hash = T::Hashing::hash_of(ext);
+                hash == ext_hash
+            })
+            .ok_or(format!("Failed to find Extrinsic with hash {:?}", ext_hash).into())
+            .into_future();
+
+        let block_hash = block_hash.clone();
+        events_stream
+            .filter(move |event| event.block == block_hash)
+            .into_future()
+            .map_err(|(e, _)| e.into())
+            .join(ext_index)
+            .and_then(move |((change_set, _), ext_index)| {
+                let events =
+                    match change_set {
+                        None => HashMap::new(),
+                        Some(change_set) => {
+                            let mut events = HashMap::new();
+                            for (_key, data) in change_set.changes {
+                                if let Some(data) = data {
+                                    if let Ok(any_events) = self.decode_events(&mut &data.0[..]) {
+                                        for (phase, module, event) in any_events {
+                                            if let Phase::ApplyExtrinsic(i) = phase {
+                                                if i as usize == ext_index {
+                                                    let events = events.entry(module).or_insert(Vec::new());
+                                                    events.push(event)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            events
+                        }
+                    };
+                future::ok(ExtrinsicSuccess {
+                    block: block_hash,
+                    extrinsic: ext_hash,
+                    events,
+                })
+            })
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -59,7 +59,7 @@ pub enum EventsError {
 }
 
 pub struct EventsDecoder<T> {
-    metadata: Metadata, // todo: borrow?
+    metadata: Metadata, // todo: [AJ] borrow?
     type_sizes: HashMap<String, usize>,
     marker: PhantomData<fn() -> T>,
 }
@@ -73,6 +73,7 @@ impl<T: System + Balances + 'static> TryFrom<Metadata> for EventsDecoder<T> {
             type_sizes: HashMap::new(),
             marker: PhantomData,
         };
+        // todo: [AJ] register and verify all required types have sizes
         decoder.register_type_size::<T::Hash>("Hash")?;
         decoder.register_type_size::<<T as Balances>::Balance>("Balance")?;
         Ok(decoder)
@@ -131,8 +132,6 @@ impl<T: System + Balances + 'static> EventsDecoder<T> {
     ) -> Result<Vec<(Phase, RawEvent)>, EventsError> {
         let compact_len = <Compact<u32>>::decode(input)?;
         let len = compact_len.0 as usize;
-
-        use substrate_primitives::hexdisplay::HexDisplay;
 
         let mut r = Vec::new();
         for _ in 0..len {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,9 +525,6 @@ mod tests {
 "#;
         let wasm = wabt::wat2wasm(CONTRACT).expect("invalid wabt");
 
-        let code_stored = node_runtime::Event::contracts(srml_contracts::RawEvent::CodeStored(Default::default()));
-        println!("TEST: {}", substrate_primitives::hexdisplay::HexDisplay::from(&code_stored.encode()));
-
         let put_code = xt
             .contracts(|call| call.put_code(500_000, wasm))
             .submit_and_watch();
@@ -535,8 +532,6 @@ mod tests {
         let success = rt
             .block_on(put_code)
             .expect("Extrinsic should be included in a block");
-
-        println!("Events {:?}", success.events);
 
         let code_hash = success
             .find_event::<<Runtime as System>::Hash>("Contracts", "CodeStored");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,8 @@ use crate::{
         balances::Balances,
         system::{
             System,
-            SystemStore,
             SystemEvent,
+            SystemStore,
         },
         ModuleCalls,
     },
@@ -80,10 +80,10 @@ mod metadata;
 mod rpc;
 mod srml;
 
-pub use srml::*;
-pub use rpc::ExtrinsicSuccess;
 pub use error::Error;
-pub use events::{RawEvent};
+pub use events::RawEvent;
+pub use rpc::ExtrinsicSuccess;
+pub use srml::*;
 
 fn connect<T: System>(url: &Url) -> impl Future<Item = Rpc<T>, Error = Error> {
     ws::connect(url).map_err(Into::into)
@@ -539,11 +539,17 @@ mod tests {
             .block_on(put_code)
             .expect("Extrinsic should be included in a block");
 
-        let code_hash = success
-            .find_event::<<Runtime as System>::Hash>("Contracts", "CodeStored");
+        let code_hash =
+            success.find_event::<<Runtime as System>::Hash>("Contracts", "CodeStored");
 
-        assert!(code_hash.is_some(), "Contracts CodeStored event should be present");
-        assert!(code_hash.unwrap().is_ok(), "CodeStored Hash should decode successfully");
+        assert!(
+            code_hash.is_some(),
+            "Contracts CodeStored event should be present"
+        );
+        assert!(
+            code_hash.unwrap().is_ok(),
+            "CodeStored Hash should decode successfully"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ use crate::{
     rpc::{
         BlockNumber,
         ChainBlock,
-        ExtrinsicSuccess,
         MapStream,
         Rpc,
     },
@@ -80,7 +79,11 @@ mod error;
 mod events;
 mod metadata;
 mod rpc;
-pub mod srml;
+mod srml;
+
+pub use srml::*;
+pub use rpc::ExtrinsicSuccess;
+pub use events::{RawEvent};
 
 fn connect<T: System>(url: &Url) -> impl Future<Item = Rpc<T>, Error = Error> {
     ws::connect(url).map_err(Into::into)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,10 @@ mod metadata;
 mod rpc;
 pub mod srml;
 
+/// Raw runtime event bytes
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+pub struct OpaqueEvent(Vec<u8>);
+
 /// Captures data for when an extrinsic is successfully included in a block
 #[derive(Debug)]
 pub struct ExtrinsicSuccess<T: System> {
@@ -79,7 +83,7 @@ pub struct ExtrinsicSuccess<T: System> {
     /// Extinsic hash.
     pub extrinsic: T::Hash,
     /// List of events.
-    pub events: Vec<T::Event>,
+    pub events: Vec<OpaqueEvent>,
 }
 
 fn connect<T: System>(url: &Url) -> impl Future<Item = Rpc<T>, Error = Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,10 @@ use runtime_primitives::{
     traits::StaticLookup,
 };
 use sr_version::RuntimeVersion;
-use std::marker::PhantomData;
+use std::{
+    convert::TryFrom,
+    marker::PhantomData,
+};
 use substrate_primitives::{
     blake2_256,
     storage::{
@@ -52,10 +55,12 @@ use url::Url;
 use crate::{
     codec::Encoded,
     events::EventsDecoder,
+    error::Error,
     metadata::MetadataError,
     rpc::{
         BlockNumber,
         ChainBlock,
+        ExtrinsicSuccess,
         MapStream,
         Rpc,
     },
@@ -69,9 +74,6 @@ use crate::{
         ModuleCalls,
     },
 };
-pub use error::Error;
-use crate::rpc::ExtrinsicSuccess;
-use std::convert::TryFrom;
 
 mod codec;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ use crate::{
         system::{
             System,
             SystemStore,
+            SystemEvent,
         },
         ModuleCalls,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@ use url::Url;
 use crate::{
     codec::Encoded,
     events::EventsDecoder,
-    error::Error,
     metadata::MetadataError,
     rpc::{
         BlockNumber,
@@ -83,6 +82,7 @@ mod srml;
 
 pub use srml::*;
 pub use rpc::ExtrinsicSuccess;
+pub use error::Error;
 pub use events::{RawEvent};
 
 fn connect<T: System>(url: &Url) -> impl Future<Item = Rpc<T>, Error = Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,7 @@ where
         // todo [AJ]: move this somewhere
         let mut listener = EventListener::new(metadata);
         listener.register_module_event_decoder::<crate::srml::contracts::Event<T>>("Contracts");
+        listener.register_module_event_decoder::<crate::srml::system::SystemEvent>("System");
 
         self.create_and_sign()
             .into_future()
@@ -515,6 +516,10 @@ mod tests {
 
         let success = rt.block_on(put_code)
             .expect("Extrinsic should be included in a block");
+
+        let system_events = success
+            .module_events::<srml::system::SystemEvent>("System");
+        println!("System events {:?}", system_events);
 
         let code_hash = success
             .module_events::<srml_contracts::Event<node_runtime::Runtime>>("Contracts")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ where
             .join(decoder)
             .and_then(move |(extrinsic, decoder)| {
                 cli.and_then(move |rpc| {
-                    rpc.submit_and_watch_extrinsic(extrinsic, &decoder)
+                    rpc.submit_and_watch_extrinsic(extrinsic, decoder)
                 })
             })
     }
@@ -524,6 +524,9 @@ mod tests {
 )
 "#;
         let wasm = wabt::wat2wasm(CONTRACT).expect("invalid wabt");
+
+        let code_stored = node_runtime::Event::contracts(srml_contracts::RawEvent::CodeStored(Default::default()));
+        println!("TEST: {}", substrate_primitives::hexdisplay::HexDisplay::from(&code_stored.encode()));
 
         let put_code = xt
             .contracts(|call| call.put_code(500_000, wasm))

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -13,13 +13,15 @@ use runtime_metadata::{
     META_RESERVED,
 };
 use std::{
-    collections::HashMap,
+    collections::{
+        HashMap,
+        HashSet,
+    },
     convert::TryFrom,
     marker::PhantomData,
     str::FromStr,
 };
 use substrate_primitives::storage::StorageKey;
-use std::collections::HashSet;
 
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum MetadataError {
@@ -42,7 +44,10 @@ impl Metadata {
         self.modules.values()
     }
 
-    pub fn module<S>(&self, name: S) -> Result<&ModuleMetadata, MetadataError> where S: ToString {
+    pub fn module<S>(&self, name: S) -> Result<&ModuleMetadata, MetadataError>
+    where
+        S: ToString,
+    {
         let name = name.to_string();
         self.modules
             .get(&name)
@@ -346,7 +351,9 @@ fn convert_module(
     })
 }
 
-fn convert_event(event: runtime_metadata::EventMetadata) -> Result<ModuleEventMetadata, Error> {
+fn convert_event(
+    event: runtime_metadata::EventMetadata,
+) -> Result<ModuleEventMetadata, Error> {
     let name = convert(event.name)?;
     let mut arguments = HashSet::new();
     for arg in convert(event.arguments)? {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -4,8 +4,8 @@ use parity_scale_codec::{
     Encode,
 };
 use runtime_metadata::{
-    EventMetadata,
     DecodeDifferent,
+    EventMetadata,
     RuntimeMetadata,
     RuntimeMetadataPrefixed,
     StorageEntryModifier,
@@ -17,9 +17,9 @@ use std::{
     collections::HashMap,
     convert::TryFrom,
     marker::PhantomData,
+    str::FromStr,
 };
 use substrate_primitives::storage::StorageKey;
-use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub enum MetadataError {
@@ -200,7 +200,10 @@ impl FromStr for EventArg {
             if let Some(end) = s.rfind(">") {
                 Ok(EventArg::Vec(Box::new(s[start..end].parse()?)))
             } else {
-                Err(Error::InvalidEventArg(s.to_string(), "Expected closing `<` for `Vec`"))
+                Err(Error::InvalidEventArg(
+                    s.to_string(),
+                    "Expected closing `<` for `Vec`",
+                ))
             }
         } else if let Some(start) = s.find("(") {
             if let Some(end) = s.rfind(")") {
@@ -211,7 +214,10 @@ impl FromStr for EventArg {
                 }
                 Ok(EventArg::Tuple(args))
             } else {
-                Err(Error::InvalidEventArg(s.to_string(), "Expecting closing `)` for tuple"))
+                Err(Error::InvalidEventArg(
+                    s.to_string(),
+                    "Expecting closing `)` for tuple",
+                ))
             }
         } else {
             Ok(EventArg::Primitive(s.to_string()))
@@ -245,7 +251,10 @@ impl TryFrom<RuntimeMetadataPrefixed> for Metadata {
             modules.insert(module_name.clone(), convert_module(i, module)?);
             modules_by_index.insert(i as u8, module_name);
         }
-        Ok(Metadata { modules, modules_by_index })
+        Ok(Metadata {
+            modules,
+            modules_by_index,
+        })
     }
 }
 
@@ -299,10 +308,7 @@ fn convert_event(event: runtime_metadata::EventMetadata) -> Result<EventMetadata
         let arg = convert_arg(arg)?.parse::<EventArg>()?;
         arguments.push(arg);
     }
-    Ok(EventMetadata {
-        name,
-        arguments,
-    })
+    Ok(EventMetadata { name, arguments })
 }
 
 fn convert_entry(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -21,7 +21,7 @@ use std::{
 use substrate_primitives::storage::StorageKey;
 use std::collections::HashSet;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum MetadataError {
     ModuleNotFound(String),
     CallNotFound(&'static str),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -14,11 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-    error::Error,
-    metadata::Metadata,
-    srml::system::System,
-};
+use crate::{error::Error, metadata::Metadata, srml::system::System, OpaqueEvent};
 use futures::future::{
     self,
     Future,
@@ -291,7 +287,7 @@ fn wait_for_block_events<T: System>(
                         .filter_map(|(_key, data)| {
                             data.as_ref().map(|data| Decode::decode(&mut &data.0[..]))
                         })
-                        .collect::<Result<Vec<Vec<EventRecord<T::Event, T::Hash>>>, _>>()
+                        .collect::<Result<Vec<Vec<EventRecord<OpaqueEvent, T::Hash>>>, _>>()
                         .map(|events| events.into_iter().flat_map(|es| es).collect())
                         .map_err(Into::into);
                     future::result(events)
@@ -302,7 +298,7 @@ fn wait_for_block_events<T: System>(
     block_events
         .join(ext_index)
         .map(move |(events, ext_index)| {
-            let events: Vec<T::Event> = events
+            let events: Vec<OpaqueEvent> = events
                 .iter()
                 .filter_map(|e| {
                     if let srml_system::Phase::ApplyExtrinsic(i) = e.phase {
@@ -315,7 +311,7 @@ fn wait_for_block_events<T: System>(
                         None
                     }
                 })
-                .collect::<Vec<T::Event>>();
+                .collect::<Vec<OpaqueEvent>>();
             ExtrinsicSuccess {
                 block: block_hash,
                 extrinsic: ext_hash,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -352,7 +352,6 @@ pub fn wait_for_block_events<T: System + Balances + 'static>(
                     let mut events = Vec::new();
                     for (_key, data) in change_set.changes {
                         if let Some(data) = data {
-                            println!("Block {:?}, DATA {}", block_hash, substrate_primitives::hexdisplay::HexDisplay::from(&data.0));
                             match decoder.decode_events(&mut &data.0[..]) {
                                 Ok(raw_events) => {
                                     for (phase, event) in raw_events {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -204,7 +204,7 @@ impl<T: System + 'static> Rpc<T> {
     pub fn submit_and_watch_extrinsic<E: 'static>(
         self,
         extrinsic: E,
-        listener: EventListener,
+        listener: EventListener<T>,
     ) -> impl Future<Item = ExtrinsicSuccess<T>, Error = Error>
     where
         E: Encode,
@@ -265,7 +265,7 @@ impl<T: System + 'static> Rpc<T> {
                         sb.block.extrinsics.len()
                     );
 
-                    listener.wait_for_block_events::<T>(ext_hash, sb, bh, events)
+                    listener.wait_for_block_events(ext_hash, sb, bh, events)
                 })
         })
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -320,6 +320,7 @@ impl<T: System> ExtrinsicSuccess<T> {
             })
     }
 
+    /// Returns all System Events
     pub fn system_events(&self) -> Vec<&SystemEvent> {
         self.events
             .iter()

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -320,7 +320,7 @@ fn wait_for_block_events<T: System>(
                 if let srml_system::Phase::ApplyExtrinsic(i) = er.phase {
                     if i as usize == ext_index {
                         let key = er.event.runtime_variant;
-                        let mut events = events.entry(key).or_insert(Vec::new());
+                        let events = events.entry(key).or_insert(Vec::new());
                         events.push(er.event.clone())
                     }
                 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -319,7 +319,7 @@ fn wait_for_block_events<T: System>(
             for er in event_records {
                 if let srml_system::Phase::ApplyExtrinsic(i) = er.phase {
                     if i as usize == ext_index {
-                        let key = (er.event.runtime_variant, er.event.module_variant);
+                        let key = er.event.runtime_variant;
                         let mut events = events.entry(key).or_insert(Vec::new());
                         events.push(er.event.clone())
                     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -133,7 +133,7 @@ use substrate_primitives::{
     twox_128,
 };
 use transaction_pool::txpool::watcher::Status;
-use crate::events::EventsDecoder;
+
 use srml_system::Phase;
 
 type MapClosure<T> = Box<dyn Fn(T) -> T + Send>;

--- a/src/srml/contracts.rs
+++ b/src/srml/contracts.rs
@@ -115,3 +115,10 @@ where
             .call("call", (dest, compact(value), compact(gas_limit), data))
     }
 }
+
+/// Contracts Events
+#[derive(parity_scale_codec::Decode)]
+pub enum Event<T: System> {
+    /// Contract code stored
+    CodeStored(T::Hash),
+}

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -3,7 +3,10 @@ use crate::{
     codec::Encoded,
     error::Error,
     metadata::MetadataError,
-    srml::{balances::Balances, ModuleCalls},
+    srml::{
+        balances::Balances,
+        ModuleCalls,
+    },
     Client,
     Valid,
     XtBuilder,

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -178,3 +178,12 @@ where
         self.module.call("set_code", code)
     }
 }
+
+/// Event for the System module.
+#[derive(Clone, Debug, parity_scale_codec::Decode)]
+pub enum SystemEvent {
+    /// An extrinsic completed successfully.
+    ExtrinsicSuccess,
+    /// An extrinsic failed.
+    ExtrinsicFailed(runtime_primitives::DispatchError),
+}

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -3,7 +3,7 @@ use crate::{
     codec::Encoded,
     error::Error,
     metadata::MetadataError,
-    srml::ModuleCalls,
+    srml::{balances::Balances, ModuleCalls},
     Client,
     Valid,
     XtBuilder,
@@ -114,7 +114,7 @@ pub trait SystemStore {
     ) -> Box<dyn Future<Item = <Self::System as System>::Index, Error = Error> + Send>;
 }
 
-impl<T: System + 'static> SystemStore for Client<T> {
+impl<T: System + Balances + 'static> SystemStore for Client<T> {
     type System = T;
 
     fn account_nonce(
@@ -152,7 +152,7 @@ pub trait SystemXt {
         ) -> Result<Encoded, MetadataError>;
 }
 
-impl<T: System + 'static, P, V> SystemXt for XtBuilder<T, P, V>
+impl<T: System + Balances + 'static, P, V> SystemXt for XtBuilder<T, P, V>
 where
     P: Pair,
 {


### PR DESCRIPTION
Removes the requirement for a top level `Event` enum to match the substrate runtime. Instead all the events for a given named module can be retrieved and decoded directly to the module `Event` enum.

This decouples the use of events from a specific substrate chain/runtime definition. 