### PR TITLE
Remove runtime dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ runtime_primitives = { git = "https://github.com/paritytech/substrate/", package
 serde = { version = "1.0", features = ["derive"] }
 sr-version = { git = "https://github.com/paritytech/substrate/", package = "sr-version" }
 srml-system = { git = "https://github.com/paritytech/substrate/", package = "srml-system" }
+srml-balances = { git = "https://github.com/paritytech/substrate/", package = "srml-balances" }
+srml-contracts = { git = "https://github.com/paritytech/substrate/", package = "srml-contracts" }
 substrate-rpc-api = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-api" }
 substrate-rpc-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-primitives" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }
@@ -34,8 +36,6 @@ url = "1.7"
 [dev-dependencies]
 env_logger = "0.6"
 node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime" }
-srml-balances = { git = "https://github.com/paritytech/substrate/", package = "srml-balances" }
-srml-contracts = { git = "https://github.com/paritytech/substrate/", package = "srml-contracts" }
 substrate-keyring = { git = "https://github.com/paritytech/substrate/", package = "substrate-keyring" }
 tokio = "0.1"
 wabt = "0.9.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
+use runtime_primitives::transaction_validity::TransactionValidityError;
 use std::io::Error as IoError;
 use substrate_primitives::crypto::SecretStringError;
 
@@ -39,6 +40,9 @@ pub enum Error {
     SecretString(SecretStringError),
     /// Metadata error.
     Metadata(MetadataError),
+    /// Extrinsic validity error
+    #[display(fmt = "Transaction Validity Error: {:?}", _0)]
+    Invalid(TransactionValidityError),
     /// Other error.
     Other(String),
 }

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -14,132 +14,147 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::{
+    codec::Encoded,
+    srml::{balances::Balances, system::System},
+};
+use parity_scale_codec::{Encode, Decode, Codec};
+use runtime_primitives::{
+    generic::{Era, UncheckedExtrinsic, SignedPayload},
+    traits::{StaticLookup, SignedExtension},
+    transaction_validity::TransactionValidityError,
+
+};
+use substrate_primitives::Pair;
 use std::marker::PhantomData;
-use crate::srml::{System, Balances};
 
 /// SignedExtra checks copied from substrate, in order to remove requirement to implement
 /// substrate's `srml_system::Trait`, and allow additional signed data to be pass
-mod extras {
-    /// Ensure the runtime version registered in the transaction is the same as at present.
-    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-    pub struct CheckVersion<T: System>(PhantomData<T>);
 
-    /// Nonce check and increment to give replay protection for transactions.
-    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-    pub struct CheckGenesis<T: System>(PhantomData<T>);
+/// Ensure the runtime version registered in the transaction is the same as at present.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckVersion<T: System>(PhantomData<T>);
 
-    /// Check for transaction mortality.
-    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-    pub struct CheckEra<T: System>((Era, PhantomData<T>));
+/// Nonce check and increment to give replay protection for transactions.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckGenesis<T: System>(PhantomData<T>);
 
-    /// Nonce check and increment to give replay protection for transactions.
-    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-    pub struct CheckNonce<T: System>(#[codec(compact)] T::Index);
+/// Check for transaction mortality.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckEra<T: System>((Era, PhantomData<T>));
 
-    /// Resource limit check.
-    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-    pub struct CheckWeight<T: Trait>(PhantomData<T>);
+/// Nonce check and increment to give replay protection for transactions.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckNonce<T: System>(#[codec(compact)] T::Index);
 
-    /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
-    /// in the queue.
-    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-    pub struct TakeFees<T: Balances>(#[codec(compact)] T::Balance);
+/// Resource limit check.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckWeight<T: System>(PhantomData<T>);
 
-    pub trait SignedExtra<T> {
-        type Extra: SignedExtension;
-        type AdditionalSigned;
+/// Require the transactor pay for themselves and maybe include a tip to gain additional priority
+/// in the queue.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct TakeFees<T: Balances>(#[codec(compact)] T::Balance);
 
-        fn extra(&self) -> Self::Extra;
-    }
+pub trait SignedExtra<T> {
+    type Extra: SignedExtension;
 
-    pub struct DefaultExtra<T: System> {
-        version: u32,
-        nonce: T::Index,
-        genesis_hash: T::Hash,
-//        marker:PhantomData<fn() -> T>
-    }
-
-    impl<T: System + Balances> DefaultExtra<T> {
-        pub fn new(version: u32, nonce: T::Index, genesis_hash: T::Hash) -> Self {
-            DefaultExtra {
-                version,
-                nonce,
-                genesis_hash,
-            }
-        }
-    }
-
-    impl<T: System + Balances> SignedExtra<T> for DefaultExtra<T> {
-        type Extra = (
-            CheckVersion<T>,
-            CheckGenesis<T>,
-            CheckEra<T>,
-            CheckNonce<T>,
-            CheckWeight<T>,
-            TakeFees<T>,
-        );
-
-        type AdditionalSigned = (
-            u32,        // CheckVersion
-            T::Hash,    // CheckGenesis
-            T::Hash,    // CheckEra(Era::Immortal)
-            (),         // CheckNonce
-            (),         // CheckWeight
-            (),         // Take Fees
-        );
-
-        fn extra(&self) -> Self::Extra {
-            (
-                CheckVersion(PhantomData),
-                CheckGenesis(PhantomData),
-                CheckEra((Era::Immortal, PhantomData)),
-                CheckNonce(self.nonce),
-                CheckWeight(PhantomData),
-                TakeFees(<T as Balances>::Balance::default())
-            )
-        }
-    }
-
-    impl<T: System + Balances> SignedExtra
+    fn extra(&self) -> Self::Extra;
 }
 
-/// Creates and signs an Extrinsic for the supplied `Call`
-pub fn create_and_sign<T, C, P, E>(
-    call: C,
+pub struct DefaultExtra<T: System> {
+    version: u32,
+    nonce: T::Index,
+    genesis_hash: T::Hash,
+    //        marker:PhantomData<fn() -> T>
+}
+
+impl<T: System + Balances> DefaultExtra<T> {
+    pub fn new(version: u32, nonce: T::Index, genesis_hash: T::Hash) -> Self {
+        DefaultExtra {
+            version,
+            nonce,
+            genesis_hash,
+        }
+    }
+}
+
+impl<T: System + Balances> SignedExtra<T> for DefaultExtra<T> {
+    type Extra = (
+        CheckVersion<T>,
+        CheckGenesis<T>,
+        CheckEra<T>,
+        CheckNonce<T>,
+        CheckWeight<T>,
+        TakeFees<T>,
+    );
+
+    fn extra(&self) -> Self::Extra {
+        (
+            CheckVersion(PhantomData),
+            CheckGenesis(PhantomData),
+            CheckEra((Era::Immortal, PhantomData)),
+            CheckNonce(self.nonce),
+            CheckWeight(PhantomData),
+            TakeFees(<T as Balances>::Balance::default()),
+        )
+    }
+}
+
+impl<T: System + Balances> SignedExtension for DefaultExtra<T> {
+    type AccountId = T::AccountId;
+    type Call = ();
+    type AdditionalSigned = (
+        u32,     // CheckVersion
+        T::Hash, // CheckGenesis
+        T::Hash, // CheckEra(Era::Immortal)
+        (),      // CheckNonce
+        (),      // CheckWeight
+        (),      // Take Fees
+    );
+    type Pre = ();
+
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+        Ok((
+            self.version,
+            self.genesis_hash,
+            self.genesis_hash,
+            (),
+            (),
+            (),
+        ))
+    }
+}
+
+pub fn create_and_sign<T: System + Balances, C, P>(
     signer: P,
-    extra: E,
+    call: C,
+    version: u32,
+    nonce: T::Index,
+    genesis_hash: T::Hash,
 ) -> Result<
     UncheckedExtrinsic<
         <T::Lookup as StaticLookup>::Source,
         Encoded,
         P::Signature,
-        T::SignedExtra,
+        DefaultExtra<T>,
     >,
-    MetadataError,
+    TransactionValidityError,
 >
-    where
-        C: Encoded,
-        P: Pair,
-        P::Public: Into<<T::Lookup as StaticLookup>::Source>,
-        P::Signature: Codec,
-        E: extras::SignedExtra,
+where
+    P: Pair,
+    P::Public: Into<<T::Lookup as StaticLookup>::Source>,
+    P::Signature: Codec,
 {
-    let raw_payload = (
-        call.clone(),
-        extra.clone(),
-        version,
-        (&genesis_hash, &genesis_hash),
-    );
-    let signature = raw_payload.using_encoded(|payload| {
-        if payload.len() > 256 {
-            signer.sign(&blake2_256(payload)[..])
-        } else {
-            signer.sign(payload)
-        }
-    });
+    let extra = DefaultExtra::new(version, nonce, genesis_hash);
+    let raw_payload = SignedPayload::new(call, extra)?;
+    let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
+    let (call, extra, _) = raw_payload.deconstruct();
 
     Ok(UncheckedExtrinsic::new_signed(
-        raw_payload.0,
+        call,
         signer.public().into(),
         signature.into(),
         extra,

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -29,10 +29,7 @@ use runtime_primitives::{
         SignedPayload,
         UncheckedExtrinsic,
     },
-    traits::{
-        SignedExtension,
-        StaticLookup,
-    },
+    traits::SignedExtension,
     transaction_validity::TransactionValidityError,
 };
 use std::marker::PhantomData;
@@ -239,7 +236,7 @@ pub fn create_and_sign<T: System + Send + Sync, C, P, E>(
     extra: E,
 ) -> Result<
     UncheckedExtrinsic<
-        <T::Lookup as StaticLookup>::Source,
+        T::Address,
         C,
         P::Signature,
         <E as SignedExtra<T>>::Extra,
@@ -248,7 +245,7 @@ pub fn create_and_sign<T: System + Send + Sync, C, P, E>(
 >
 where
     P: Pair,
-    P::Public: Into<<T::Lookup as StaticLookup>::Source>,
+    P::Public: Into<T::Address>,
     P::Signature: Codec,
     C: Encode,
     E: SignedExtra<T> + SignedExtension,

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -42,7 +42,7 @@ use substrate_primitives::Pair;
 /// substrate's `srml_system::Trait`
 
 macro_rules! impl_signed_extensions {
-    ( $( ($name:ident, $mod:ident, $ty:ty, $self:ident, $f:ident, $res:expr, $fmt:expr) ),* ) => {
+    ( $( ($name:ident, $mod:ident, $ty:ty, $self:ident, $res:expr) ),* ) => {
         $(
             impl<T> SignedExtension for $name<T> where T: $mod + Send + Sync {
                 type AccountId = u64;
@@ -53,32 +53,20 @@ macro_rules! impl_signed_extensions {
                     Ok($res)
                 }
             }
-
-            impl<T> std::fmt::Debug for $name<T> where T: $mod + Send + Sync {
-                fn fmt(&$self, $f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    $fmt
-                }
-            }
         )*
     }
 }
 
+// CheckVersion<T: System> { fn additional_signed(&self) -> u32 { self.1 } }
+
 impl_signed_extensions!(
-    (CheckVersion, System, u32, self, f, self.1, self.1.fmt(f)),
-    (
-        CheckGenesis,
-        System,
-        T::Hash,
-        self,
-        f,
-        self.1,
-        self.1.fmt(f)
-    ),
-    (CheckEra, System, T::Hash, self, f, self.1, self.1.fmt(f)),
-    (CheckNonce, System, (), self, f, (), self.0.fmt(f)),
-    (CheckWeight, System, (), self, _f, (), Ok(())),
-    (TakeFees, Balances, (), self, f, (), self.0.fmt(f)),
-    (CheckBlockGasLimit, System, (), self, _f, (), Ok(()))
+    (CheckVersion, System, u32, self, self.1),
+    (CheckGenesis, System, T::Hash, self, self.1),
+    (CheckEra, System, T::Hash, self, self.1),
+    (CheckNonce, System, (), self, ()),
+    (CheckWeight, System, (), self, ()),
+    (TakeFees, Balances, (), self, ()),
+    (CheckBlockGasLimit, System, (), self, ())
 );
 
 /// Ensure the runtime version registered in the transaction is the same as at present.
@@ -87,7 +75,7 @@ impl_signed_extensions!(
 ///
 /// This is modified from the substrate version to allow passing in of the version, which is
 /// returned via `additional_signed()`.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckVersion<T: System + Send + Sync>(
     PhantomData<T>,
     /// Local version to be used for `AdditionalSigned`
@@ -101,7 +89,7 @@ pub struct CheckVersion<T: System + Send + Sync>(
 ///
 /// This is modified from the substrate version to allow passing in of the genesis hash, which is
 /// returned via `additional_signed()`.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckGenesis<T: System + Send + Sync>(
     PhantomData<T>,
     /// Local genesis hash to be used for `AdditionalSigned`
@@ -116,7 +104,7 @@ pub struct CheckGenesis<T: System + Send + Sync>(
 /// This is modified from the substrate version to allow passing in of the genesis hash, which is
 /// returned via `additional_signed()`. It assumes therefore `Era::Immortal` (The transaction is
 /// valid forever)
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckEra<T: System + Send + Sync>(
     /// The default structure for the Extra encoding
     (Era, PhantomData<T>),
@@ -126,20 +114,20 @@ pub struct CheckEra<T: System + Send + Sync>(
 );
 
 /// Nonce check and increment to give replay protection for transactions.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckNonce<T: System + Send + Sync>(#[codec(compact)] T::Index);
 
 /// Resource limit check.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckWeight<T: System + Send + Sync>(PhantomData<T>);
 
 /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
 /// in the queue.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct TakeFees<T: Balances>(#[codec(compact)] T::Balance);
 
 /// Checks if a transaction would exhausts the block gas limit.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckBlockGasLimit<T: System + Send + Sync>(PhantomData<T>);
 
 pub trait SignedExtra<T> {

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -14,18 +14,29 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-    srml::{balances::Balances, system::System},
+use crate::srml::{
+    balances::Balances,
+    system::System,
 };
-use parity_scale_codec::{Encode, Decode, Codec};
+use parity_scale_codec::{
+    Codec,
+    Decode,
+    Encode,
+};
 use runtime_primitives::{
-    generic::{Era, UncheckedExtrinsic, SignedPayload},
-    traits::{StaticLookup, SignedExtension},
+    generic::{
+        Era,
+        SignedPayload,
+        UncheckedExtrinsic,
+    },
+    traits::{
+        SignedExtension,
+        StaticLookup,
+    },
     transaction_validity::TransactionValidityError,
-
 };
-use substrate_primitives::Pair;
 use std::marker::PhantomData;
+use substrate_primitives::Pair;
 
 /// SignedExtra checks copied from substrate, in order to remove requirement to implement
 /// substrate's `srml_system::Trait`
@@ -54,7 +65,15 @@ macro_rules! impl_signed_extensions {
 
 impl_signed_extensions!(
     (CheckVersion, System, u32, self, f, self.1, self.1.fmt(f)),
-    (CheckGenesis, System, T::Hash, self, f, self.1, self.1.fmt(f)),
+    (
+        CheckGenesis,
+        System,
+        T::Hash,
+        self,
+        f,
+        self.1,
+        self.1.fmt(f)
+    ),
     (CheckEra, System, T::Hash, self, f, self.1, self.1.fmt(f)),
     (CheckNonce, System, (), self, f, (), self.0.fmt(f)),
     (CheckWeight, System, (), self, _f, (), Ok(())),
@@ -71,7 +90,8 @@ impl_signed_extensions!(
 pub struct CheckVersion<T: System + Send + Sync>(
     PhantomData<T>,
     /// Local version to be used for `AdditionalSigned`
-    #[codec(skip)] u32,
+    #[codec(skip)]
+    u32,
 );
 
 /// Check genesis hash
@@ -84,7 +104,8 @@ pub struct CheckVersion<T: System + Send + Sync>(
 pub struct CheckGenesis<T: System + Send + Sync>(
     PhantomData<T>,
     /// Local genesis hash to be used for `AdditionalSigned`
-    #[codec(skip)] T::Hash,
+    #[codec(skip)]
+    T::Hash,
 );
 
 /// Check for transaction mortality.
@@ -99,7 +120,8 @@ pub struct CheckEra<T: System + Send + Sync>(
     /// The default structure for the Extra encoding
     (Era, PhantomData<T>),
     /// Local genesis hash to be used for `AdditionalSigned`
-    #[codec(skip)] T::Hash,
+    #[codec(skip)]
+    T::Hash,
 );
 
 /// Nonce check and increment to give replay protection for transactions.
@@ -163,7 +185,8 @@ impl<T: System + Balances + Send + Sync> SignedExtra<T> for DefaultExtra<T> {
 impl<T: System + Balances + Send + Sync> SignedExtension for DefaultExtra<T> {
     type AccountId = T::AccountId;
     type Call = ();
-    type AdditionalSigned = <<Self as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned;
+    type AdditionalSigned =
+        <<Self as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned;
     type Pre = ();
 
     fn additional_signed(

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -77,7 +77,8 @@ impl_signed_extensions!(
     (CheckEra, System, T::Hash, self, f, self.1, self.1.fmt(f)),
     (CheckNonce, System, (), self, f, (), self.0.fmt(f)),
     (CheckWeight, System, (), self, _f, (), Ok(())),
-    (TakeFees, Balances, (), self, f, (), self.0.fmt(f))
+    (TakeFees, Balances, (), self, f, (), self.0.fmt(f)),
+    (CheckBlockGasLimit, System, (), self, _f, (), Ok(()))
 );
 
 /// Ensure the runtime version registered in the transaction is the same as at present.
@@ -137,6 +138,10 @@ pub struct CheckWeight<T: System + Send + Sync>(PhantomData<T>);
 #[derive(Encode, Decode, Clone, Eq, PartialEq)]
 pub struct TakeFees<T: Balances>(#[codec(compact)] T::Balance);
 
+/// Checks if a transaction would exhausts the block gas limit.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckBlockGasLimit<T: System + Send + Sync>(PhantomData<T>);
+
 pub trait SignedExtra<T> {
     type Extra: SignedExtension;
 
@@ -168,6 +173,7 @@ impl<T: System + Balances + Send + Sync> SignedExtra<T> for DefaultExtra<T> {
         CheckNonce<T>,
         CheckWeight<T>,
         TakeFees<T>,
+        CheckBlockGasLimit<T>,
     );
 
     fn extra(&self) -> Self::Extra {
@@ -178,6 +184,7 @@ impl<T: System + Balances + Send + Sync> SignedExtra<T> for DefaultExtra<T> {
             CheckNonce(self.nonce),
             CheckWeight(PhantomData),
             TakeFees(<T as Balances>::Balance::default()),
+            CheckBlockGasLimit(PhantomData),
         )
     }
 }

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -1,0 +1,147 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of substrate-subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::marker::PhantomData;
+use crate::srml::{System, Balances};
+
+/// SignedExtra checks copied from substrate, in order to remove requirement to implement
+/// substrate's `srml_system::Trait`, and allow additional signed data to be pass
+mod extras {
+    /// Ensure the runtime version registered in the transaction is the same as at present.
+    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
+    pub struct CheckVersion<T: System>(PhantomData<T>);
+
+    /// Nonce check and increment to give replay protection for transactions.
+    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
+    pub struct CheckGenesis<T: System>(PhantomData<T>);
+
+    /// Check for transaction mortality.
+    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
+    pub struct CheckEra<T: System>((Era, PhantomData<T>));
+
+    /// Nonce check and increment to give replay protection for transactions.
+    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
+    pub struct CheckNonce<T: System>(#[codec(compact)] T::Index);
+
+    /// Resource limit check.
+    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
+    pub struct CheckWeight<T: Trait>(PhantomData<T>);
+
+    /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
+    /// in the queue.
+    #[derive(Encode, Decode, Clone, Eq, PartialEq)]
+    pub struct TakeFees<T: Balances>(#[codec(compact)] T::Balance);
+
+    pub trait SignedExtra<T> {
+        type Extra: SignedExtension;
+        type AdditionalSigned;
+
+        fn extra(&self) -> Self::Extra;
+    }
+
+    pub struct DefaultExtra<T: System> {
+        version: u32,
+        nonce: T::Index,
+        genesis_hash: T::Hash,
+//        marker:PhantomData<fn() -> T>
+    }
+
+    impl<T: System + Balances> DefaultExtra<T> {
+        pub fn new(version: u32, nonce: T::Index, genesis_hash: T::Hash) -> Self {
+            DefaultExtra {
+                version,
+                nonce,
+                genesis_hash,
+            }
+        }
+    }
+
+    impl<T: System + Balances> SignedExtra<T> for DefaultExtra<T> {
+        type Extra = (
+            CheckVersion<T>,
+            CheckGenesis<T>,
+            CheckEra<T>,
+            CheckNonce<T>,
+            CheckWeight<T>,
+            TakeFees<T>,
+        );
+
+        type AdditionalSigned = (
+            u32,        // CheckVersion
+            T::Hash,    // CheckGenesis
+            T::Hash,    // CheckEra(Era::Immortal)
+            (),         // CheckNonce
+            (),         // CheckWeight
+            (),         // Take Fees
+        );
+
+        fn extra(&self) -> Self::Extra {
+            (
+                CheckVersion(PhantomData),
+                CheckGenesis(PhantomData),
+                CheckEra((Era::Immortal, PhantomData)),
+                CheckNonce(self.nonce),
+                CheckWeight(PhantomData),
+                TakeFees(<T as Balances>::Balance::default())
+            )
+        }
+    }
+
+    impl<T: System + Balances> SignedExtra
+}
+
+/// Creates and signs an Extrinsic for the supplied `Call`
+pub fn create_and_sign<T, C, P, E>(
+    call: C,
+    signer: P,
+    extra: E,
+) -> Result<
+    UncheckedExtrinsic<
+        <T::Lookup as StaticLookup>::Source,
+        Encoded,
+        P::Signature,
+        T::SignedExtra,
+    >,
+    MetadataError,
+>
+    where
+        C: Encoded,
+        P: Pair,
+        P::Public: Into<<T::Lookup as StaticLookup>::Source>,
+        P::Signature: Codec,
+        E: extras::SignedExtra,
+{
+    let raw_payload = (
+        call.clone(),
+        extra.clone(),
+        version,
+        (&genesis_hash, &genesis_hash),
+    );
+    let signature = raw_payload.using_encoded(|payload| {
+        if payload.len() > 256 {
+            signer.sign(&blake2_256(payload)[..])
+        } else {
+            signer.sign(payload)
+        }
+    });
+
+    Ok(UncheckedExtrinsic::new_signed(
+        raw_payload.0,
+        signer.public().into(),
+        signature.into(),
+        extra,
+    ))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,6 @@ mod tests {
         type AccountId = <node_runtime::Runtime as srml_system::Trait>::AccountId;
         type Lookup = <node_runtime::Runtime as srml_system::Trait>::Lookup;
         type Header = <node_runtime::Runtime as srml_system::Trait>::Header;
-        type Event = <node_runtime::Runtime as srml_system::Trait>::Event;
 
         type SignedExtra = (
             srml_system::CheckVersion<node_runtime::Runtime>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,25 +452,6 @@ mod tests {
         type AccountId = <node_runtime::Runtime as srml_system::Trait>::AccountId;
         type Lookup = <node_runtime::Runtime as srml_system::Trait>::Lookup;
         type Header = <node_runtime::Runtime as srml_system::Trait>::Header;
-
-        type SignedExtra = (
-            srml_system::CheckVersion<node_runtime::Runtime>,
-            srml_system::CheckGenesis<node_runtime::Runtime>,
-            srml_system::CheckEra<node_runtime::Runtime>,
-            srml_system::CheckNonce<node_runtime::Runtime>,
-            srml_system::CheckWeight<node_runtime::Runtime>,
-            srml_balances::TakeFees<node_runtime::Runtime>,
-        );
-        fn extra(nonce: Self::Index) -> Self::SignedExtra {
-            (
-                srml_system::CheckVersion::<node_runtime::Runtime>::new(),
-                srml_system::CheckGenesis::<node_runtime::Runtime>::new(),
-                srml_system::CheckEra::<node_runtime::Runtime>::from(Era::Immortal),
-                srml_system::CheckNonce::<node_runtime::Runtime>::from(nonce),
-                srml_system::CheckWeight::<node_runtime::Runtime>::new(),
-                srml_balances::TakeFees::<node_runtime::Runtime>::from(0),
-            )
-        }
     }
 
     impl Balances for Runtime {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,13 @@ where
             account_nonce
         );
 
-        let xt = extrinsic::create_and_sign(signer, call, version, account_nonce, genesis_hash)?;
+        let xt = extrinsic::create_and_sign(
+            signer,
+            call,
+            version,
+            account_nonce,
+            genesis_hash,
+        )?;
         Ok(xt)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,10 @@ use url::Url;
 use crate::{
     codec::Encoded,
     events::EventsDecoder,
+    extrinsic::{
+        DefaultExtra,
+        SignedExtra,
+    },
     metadata::MetadataError,
     rpc::{
         BlockNumber,
@@ -337,7 +341,7 @@ where
             <T::Lookup as StaticLookup>::Source,
             Encoded,
             P::Signature,
-            extrinsic::DefaultExtra<T>,
+            <DefaultExtra<T> as SignedExtra<T>>::Extra,
         >,
         Error,
     >
@@ -361,13 +365,8 @@ where
             account_nonce
         );
 
-        let xt = extrinsic::create_and_sign(
-            signer,
-            call,
-            version,
-            account_nonce,
-            genesis_hash,
-        )?;
+        let extra = extrinsic::DefaultExtra::new(version, account_nonce, genesis_hash);
+        let xt = extrinsic::create_and_sign(signer, call, extra)?;
         Ok(xt)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,12 +407,10 @@ mod tests {
             BalancesStore,
             BalancesXt,
         },
-        contracts::{
-            Contracts,
-            ContractsXt,
-        },
+        contracts::ContractsXt,
     };
     use futures::stream::Stream;
+    use node_runtime::Runtime;
     use parity_scale_codec::Encode;
     use runtime_support::StorageMap;
     use substrate_keyring::AccountKeyring;
@@ -420,25 +418,6 @@ mod tests {
         storage::StorageKey,
         Pair,
     };
-
-    #[derive(Eq, PartialEq, Clone, Debug)]
-    struct Runtime;
-
-    impl System for Runtime {
-        type Index = <node_runtime::Runtime as srml_system::Trait>::Index;
-        type BlockNumber = <node_runtime::Runtime as srml_system::Trait>::BlockNumber;
-        type Hash = <node_runtime::Runtime as srml_system::Trait>::Hash;
-        type Hashing = <node_runtime::Runtime as srml_system::Trait>::Hashing;
-        type AccountId = <node_runtime::Runtime as srml_system::Trait>::AccountId;
-        type Lookup = <node_runtime::Runtime as srml_system::Trait>::Lookup;
-        type Header = <node_runtime::Runtime as srml_system::Trait>::Header;
-    }
-
-    impl Balances for Runtime {
-        type Balance = <node_runtime::Runtime as srml_balances::Trait>::Balance;
-    }
-
-    impl Contracts for Runtime {}
 
     type Index = <Runtime as System>::Index;
     type AccountId = <Runtime as System>::AccountId;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ where
             P::Signature,
             extrinsic::DefaultExtra<T>,
         >,
-        MetadataError,
+        Error,
     >
     where
         P: Pair,
@@ -361,7 +361,8 @@ where
             account_nonce
         );
 
-        extrinsic::create_and_sign(call, version, account_nonce, genesis_hash)
+        let xt = extrinsic::create_and_sign(signer, call, version, account_nonce, genesis_hash)?;
+        Ok(xt)
     }
 
     /// Submits a transaction to the chain.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,7 @@ use parity_scale_codec::{
     Codec,
     Decode,
 };
-use runtime_primitives::{
-    generic::UncheckedExtrinsic,
-    traits::StaticLookup,
-};
+use runtime_primitives::generic::UncheckedExtrinsic;
 use sr_version::RuntimeVersion;
 use std::{
     convert::TryFrom,
@@ -238,7 +235,7 @@ impl<T: System + Balances + 'static> Client<T> {
     ) -> impl Future<Item = XtBuilder<T, P>, Error = Error>
     where
         P: Pair,
-        P::Public: Into<T::AccountId> + Into<<T::Lookup as StaticLookup>::Source>,
+        P::Public: Into<T::AccountId> + Into<T::Address>,
         P::Signature: Codec,
     {
         let client = self.clone();
@@ -330,7 +327,7 @@ where
 impl<T: System + Balances + Send + Sync + 'static, P> XtBuilder<T, P, Valid>
 where
     P: Pair,
-    P::Public: Into<<T::Lookup as StaticLookup>::Source>,
+    P::Public: Into<T::Address>,
     P::Signature: Codec,
 {
     /// Creates and signs an Extrinsic for the supplied `Call`
@@ -338,7 +335,7 @@ where
         &self,
     ) -> Result<
         UncheckedExtrinsic<
-            <T::Lookup as StaticLookup>::Source,
+            T::Address,
             Encoded,
             P::Signature,
             <DefaultExtra<T> as SignedExtra<T>>::Extra,
@@ -347,7 +344,7 @@ where
     >
     where
         P: Pair,
-        P::Public: Into<<T::Lookup as StaticLookup>::Source>,
+        P::Public: Into<T::Address>,
         P::Signature: Codec,
     {
         let signer = self.signer.clone();
@@ -426,7 +423,7 @@ mod tests {
 
     type Index = <Runtime as System>::Index;
     type AccountId = <Runtime as System>::AccountId;
-    type Address = <<Runtime as System>::Lookup as StaticLookup>::Source;
+    type Address = <Runtime as System>::Address;
     type Balance = <Runtime as Balances>::Balance;
 
     fn test_setup() -> (tokio::runtime::Runtime, Client<Runtime>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ where
     }
 }
 
-impl<T: System + Balances + 'static, P> XtBuilder<T, P, Valid>
+impl<T: System + Balances + Send + Sync + 'static, P> XtBuilder<T, P, Valid>
 where
     P: Pair,
     P::Public: Into<<T::Lookup as StaticLookup>::Source>,
@@ -420,6 +420,7 @@ mod tests {
         Pair,
     };
 
+    #[derive(Eq, PartialEq, Clone, Debug)]
     struct Runtime;
 
     impl System for Runtime {

--- a/src/srml/balances.rs
+++ b/src/srml/balances.rs
@@ -23,7 +23,6 @@ use runtime_primitives::traits::{
     MaybeSerializeDebug,
     Member,
     SimpleArithmetic,
-    StaticLookup,
 };
 use runtime_support::Parameter;
 use substrate_primitives::Pair;
@@ -142,7 +141,7 @@ where
     /// of the transfer, the account will be reaped.
     pub fn transfer(
         self,
-        to: <<T as System>::Lookup as StaticLookup>::Source,
+        to: <T as System>::Address,
         amount: <T as Balances>::Balance,
     ) -> Result<Encoded, MetadataError> {
         self.module.call("transfer", (to, compact(amount)))

--- a/src/srml/balances.rs
+++ b/src/srml/balances.rs
@@ -42,7 +42,10 @@ pub trait Balances: System {
 }
 
 /// Blanket impl for using existing runtime types
-impl<T: srml_system::Trait + srml_balances::Trait + std::fmt::Debug> Balances for T where <T as srml_system::Trait>::Header: serde::de::DeserializeOwned {
+impl<T: srml_system::Trait + srml_balances::Trait + std::fmt::Debug> Balances for T
+where
+    <T as srml_system::Trait>::Header: serde::de::DeserializeOwned,
+{
     type Balance = T::Balance;
 }
 

--- a/src/srml/balances.rs
+++ b/src/srml/balances.rs
@@ -41,6 +41,11 @@ pub trait Balances: System {
         + From<<Self as System>::BlockNumber>;
 }
 
+/// Blanket impl for using existing runtime types
+impl<T: srml_system::Trait + srml_balances::Trait + std::fmt::Debug> Balances for T where <T as srml_system::Trait>::Header: serde::de::DeserializeOwned {
+    type Balance = T::Balance;
+}
+
 /// The Balances extension trait for the Client.
 pub trait BalancesStore {
     /// Balances type.

--- a/src/srml/contracts.rs
+++ b/src/srml/contracts.rs
@@ -24,7 +24,15 @@ pub type Gas = u64;
 pub trait Contracts: System + Balances {}
 
 /// Blanket impl for using existing runtime types
-impl<T: srml_contracts::Trait + srml_system::Trait + srml_balances::Trait + std::fmt::Debug> Contracts for T where <T as srml_system::Trait>::Header: serde::de::DeserializeOwned {
+impl<
+        T: srml_contracts::Trait
+            + srml_system::Trait
+            + srml_balances::Trait
+            + std::fmt::Debug,
+    > Contracts for T
+where
+    <T as srml_system::Trait>::Header: serde::de::DeserializeOwned,
+{
 }
 
 /// The Contracts extension trait for the XtBuilder.

--- a/src/srml/contracts.rs
+++ b/src/srml/contracts.rs
@@ -23,6 +23,10 @@ pub type Gas = u64;
 /// The subset of the `srml_contracts::Trait` that a client must implement.
 pub trait Contracts: System + Balances {}
 
+/// Blanket impl for using existing runtime types
+impl<T: srml_contracts::Trait + srml_system::Trait + srml_balances::Trait + std::fmt::Debug> Contracts for T where <T as srml_system::Trait>::Header: serde::de::DeserializeOwned {
+}
+
 /// The Contracts extension trait for the XtBuilder.
 pub trait ContractsXt {
     /// Contracts type.

--- a/src/srml/contracts.rs
+++ b/src/srml/contracts.rs
@@ -13,7 +13,6 @@ use crate::{
     Valid,
     XtBuilder,
 };
-use runtime_primitives::traits::StaticLookup;
 use substrate_primitives::Pair;
 
 /// Gas units are chosen to be represented by u64 so that gas metering
@@ -118,7 +117,7 @@ where
     ///  will be transferred.
     pub fn call(
         &self,
-        dest: <<T as System>::Lookup as StaticLookup>::Source,
+        dest: <T as System>::Address,
         value: <T as Balances>::Balance,
         gas_limit: Gas,
         data: Vec<u8>,

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -93,12 +93,17 @@ pub trait System {
     type Header: Parameter
         + Header<Number = Self::BlockNumber, Hash = Self::Hash>
         + DeserializeOwned;
+}
 
-    /// The `SignedExtension` to the basic transaction logic.
-    type SignedExtra: SignedExtension;
-
-    /// Creates the `SignedExtra` from the account nonce.
-    fn extra(nonce: Self::Index) -> Self::SignedExtra;
+/// Blanket impl for using existing runtime types
+impl<T: srml_system::Trait> System for T {
+    type Index = T::Index;
+    type BlockNumber = T::BlockNumber;
+    type Hash = T::Hash;
+    type Hashing = T::Hashing;
+    type AccountId = T::AccountId;
+    type Lookup = T::Lookup;
+    type Header = T::Header;
 }
 
 /// The System extension trait for the Client.

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -15,11 +15,13 @@ use futures::future::{
     self,
     Future,
 };
+use parity_scale_codec::Codec;
 use runtime_primitives::traits::{
     Bounded,
     CheckEqual,
     Hash,
     Header,
+    MaybeDebug,
     MaybeDisplay,
     MaybeSerializeDebug,
     MaybeSerializeDebugButNotDeserialize,
@@ -79,14 +81,8 @@ pub trait System: 'static + Eq + Clone + std::fmt::Debug {
         + Ord
         + Default;
 
-    /// Converting trait to take a source type and convert to `AccountId`.
-    ///
-    /// Used to define the type and conversion mechanism for referencing
-    /// accounts in transactions. It's perfectly reasonable for this to be an
-    /// identity conversion (with the source type being `AccountId`), but other
-    /// modules (e.g. Indices module) may provide more functional/efficient
-    /// alternatives.
-    type Lookup: StaticLookup<Target = Self::AccountId>;
+    /// The address type. This instead of `<srml_system::Trait::Lookup as StaticLookup>::Source`.
+    type Address: Codec + Clone + PartialEq + MaybeDebug;
 
     /// The block header.
     type Header: Parameter
@@ -104,7 +100,7 @@ where
     type Hash = T::Hash;
     type Hashing = T::Hashing;
     type AccountId = T::AccountId;
-    type Lookup = T::Lookup;
+    type Address = <T::Lookup as StaticLookup>::Source;
     type Header = T::Header;
 }
 

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -95,7 +95,10 @@ pub trait System: 'static + Eq + Clone + std::fmt::Debug {
 }
 
 /// Blanket impl for using existing runtime types
-impl<T: srml_system::Trait + std::fmt::Debug> System for T where <T as srml_system::Trait>::Header: serde::de::DeserializeOwned {
+impl<T: srml_system::Trait + std::fmt::Debug> System for T
+where
+    <T as srml_system::Trait>::Header: serde::de::DeserializeOwned,
+{
     type Index = T::Index;
     type BlockNumber = T::BlockNumber;
     type Hash = T::Hash;

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -31,7 +31,6 @@ use runtime_primitives::traits::{
 };
 use runtime_support::Parameter;
 use serde::de::DeserializeOwned;
-use srml_system::Event;
 use substrate_primitives::Pair;
 
 /// The subset of the `srml_system::Trait` that a client must implement.
@@ -94,9 +93,6 @@ pub trait System {
     type Header: Parameter
         + Header<Number = Self::BlockNumber, Hash = Self::Hash>
         + DeserializeOwned;
-
-    /// The aggregated event type of the runtime.
-    type Event: Parameter + Member + From<Event>;
 
     /// The `SignedExtension` to the basic transaction logic.
     type SignedExtra: SignedExtension;

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -24,7 +24,6 @@ use runtime_primitives::traits::{
     MaybeSerializeDebug,
     MaybeSerializeDebugButNotDeserialize,
     Member,
-    SignedExtension,
     SimpleArithmetic,
     SimpleBitOps,
     StaticLookup,

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -33,7 +33,7 @@ use serde::de::DeserializeOwned;
 use substrate_primitives::Pair;
 
 /// The subset of the `srml_system::Trait` that a client must implement.
-pub trait System {
+pub trait System: 'static + Eq + Clone + std::fmt::Debug {
     /// Account index (aka nonce) type. This stores the number of previous
     /// transactions associated with a sender account.
     type Index: Parameter
@@ -95,7 +95,7 @@ pub trait System {
 }
 
 /// Blanket impl for using existing runtime types
-impl<T: srml_system::Trait> System for T {
+impl<T: srml_system::Trait + std::fmt::Debug> System for T where <T as srml_system::Trait>::Header: serde::de::DeserializeOwned {
     type Index = T::Index;
     type BlockNumber = T::BlockNumber;
     type Hash = T::Hash;


### PR DESCRIPTION
This PR removes the requirement of a concrete implementation of a substrate runtime (e.g. `node_runtime`).

The main change here is to copy the "Check" types across from substrate which add additional signed data to an extrinsic. This allows us to break the dependency on `srml_system::Trait` for which a concrete implementation is required. Instead we can use the local `System` trait which defines only the types we need. 

Additionally if the user does still want to use their predefined substrate Runtime - this PR provides some blanket impls for converting to the local traits.