### PR TITLE
Define `node_runtime` compatible Runtime types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ sr-version = { git = "https://github.com/paritytech/substrate/", package = "sr-v
 srml-system = { git = "https://github.com/paritytech/substrate/", package = "srml-system" }
 srml-balances = { git = "https://github.com/paritytech/substrate/", package = "srml-balances" }
 srml-contracts = { git = "https://github.com/paritytech/substrate/", package = "srml-contracts" }
+srml-indices = { git = "https://github.com/paritytech/substrate/", package = "srml-indices" }
 substrate-rpc-api = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-api" }
 substrate-rpc-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-primitives" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }

--- a/src/extrinsic.rs
+++ b/src/extrinsic.rs
@@ -52,12 +52,17 @@ pub struct CheckVersion<T: System + Send + Sync>(
     u32,
 );
 
-impl<T> SignedExtension for CheckVersion<T> where T: System + Send + Sync {
+impl<T> SignedExtension for CheckVersion<T>
+where
+    T: System + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = u32;
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
     }
 }
@@ -76,12 +81,17 @@ pub struct CheckGenesis<T: System + Send + Sync>(
     T::Hash,
 );
 
-impl<T> SignedExtension for CheckGenesis<T> where T: System + Send + Sync {
+impl<T> SignedExtension for CheckGenesis<T>
+where
+    T: System + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = T::Hash;
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
     }
 }
@@ -102,12 +112,17 @@ pub struct CheckEra<T: System + Send + Sync>(
     T::Hash,
 );
 
-impl<T> SignedExtension for CheckEra<T> where T: System + Send + Sync {
+impl<T> SignedExtension for CheckEra<T>
+where
+    T: System + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = T::Hash;
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
     }
 }
@@ -116,12 +131,17 @@ impl<T> SignedExtension for CheckEra<T> where T: System + Send + Sync {
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckNonce<T: System + Send + Sync>(#[codec(compact)] T::Index);
 
-impl<T> SignedExtension for CheckNonce<T> where T: System + Send + Sync {
+impl<T> SignedExtension for CheckNonce<T>
+where
+    T: System + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = ();
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
 }
@@ -130,12 +150,17 @@ impl<T> SignedExtension for CheckNonce<T> where T: System + Send + Sync {
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckWeight<T: System + Send + Sync>(PhantomData<T>);
 
-impl<T> SignedExtension for CheckWeight<T> where T: System + Send + Sync {
+impl<T> SignedExtension for CheckWeight<T>
+where
+    T: System + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = ();
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
 }
@@ -145,12 +170,17 @@ impl<T> SignedExtension for CheckWeight<T> where T: System + Send + Sync {
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct TakeFees<T: Balances>(#[codec(compact)] T::Balance);
 
-impl<T> SignedExtension for TakeFees<T> where T: Balances + Send + Sync {
+impl<T> SignedExtension for TakeFees<T>
+where
+    T: Balances + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = ();
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
 }
@@ -159,12 +189,17 @@ impl<T> SignedExtension for TakeFees<T> where T: Balances + Send + Sync {
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CheckBlockGasLimit<T: System + Send + Sync>(PhantomData<T>);
 
-impl<T> SignedExtension for CheckBlockGasLimit<T> where T: System + Send + Sync {
+impl<T> SignedExtension for CheckBlockGasLimit<T>
+where
+    T: System + Send + Sync,
+{
     type AccountId = u64;
     type Call = ();
     type AdditionalSigned = ();
     type Pre = ();
-    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+    fn additional_signed(
+        &self,
+    ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
 }
@@ -235,12 +270,7 @@ pub fn create_and_sign<T: System + Send + Sync, C, P, E>(
     call: C,
     extra: E,
 ) -> Result<
-    UncheckedExtrinsic<
-        T::Address,
-        C,
-        P::Signature,
-        <E as SignedExtra<T>>::Extra,
-    >,
+    UncheckedExtrinsic<T::Address, C, P::Signature, <E as SignedExtra<T>>::Extra>,
     TransactionValidityError,
 >
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,14 @@ mod events;
 mod extrinsic;
 mod metadata;
 mod rpc;
+mod runtimes;
 mod srml;
 
 pub use error::Error;
 pub use events::RawEvent;
 pub use rpc::ExtrinsicSuccess;
 pub use srml::*;
+pub use runtimes::*;
 
 fn connect<T: System>(url: &Url) -> impl Future<Item = Rpc<T>, Error = Error> {
     ws::connect(url).map_err(Into::into)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ mod srml;
 pub use error::Error;
 pub use events::RawEvent;
 pub use rpc::ExtrinsicSuccess;
-pub use srml::*;
 pub use runtimes::*;
+pub use srml::*;
 
 fn connect<T: System>(url: &Url) -> impl Future<Item = Rpc<T>, Error = Error> {
     ws::connect(url).map_err(Into::into)

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -1,0 +1,51 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of substrate-subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::srml::{
+    system::System,
+    balances::Balances,
+    contracts::Contracts,
+};
+use runtime_primitives::{
+    generic::Header,
+    traits::{Verify, BlakeTwo256},
+    AnySignature,
+};
+
+/// Concrete type definitions compatible with those in the default substrate `node_runtime`
+///
+/// # Note
+///
+/// If the concrete types in the target substrate runtime differ from these, a custom Runtime
+/// definition MUST be used to ensure type compatibility.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DefaultNodeRuntime;
+
+impl System for DefaultNodeRuntime {
+    type Index = u32;
+    type BlockNumber = u32;
+    type Hash = substrate_primitives::H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = <AnySignature as Verify>::Signer;
+    type Address = srml_indices::address::Address<Self::AccountId, u32>;
+    type Header = Header<Self::BlockNumber, BlakeTwo256>;
+}
+
+impl Balances for DefaultNodeRuntime {
+    type Balance = u64;
+}
+
+impl Contracts for DefaultNodeRuntime {}

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -15,13 +15,16 @@
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::srml::{
-    system::System,
     balances::Balances,
     contracts::Contracts,
+    system::System,
 };
 use runtime_primitives::{
     generic::Header,
-    traits::{Verify, BlakeTwo256},
+    traits::{
+        BlakeTwo256,
+        Verify,
+    },
     AnySignature,
 };
 


### PR DESCRIPTION
Matches concrete type definitions in substrate's `node_runtime` for convenience.