### PR TITLE
Event arguments are Vec not HashSet

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -13,10 +13,7 @@ use runtime_metadata::{
     META_RESERVED,
 };
 use std::{
-    collections::{
-        HashMap,
-        HashSet,
-    },
+    collections::HashMap,
     convert::TryFrom,
     marker::PhantomData,
     str::FromStr,
@@ -197,7 +194,7 @@ impl<K: Encode, V: Decode + Clone> StorageMap<K, V> {
 #[derive(Clone, Debug)]
 pub struct ModuleEventMetadata {
     pub name: String,
-    arguments: HashSet<EventArg>,
+    arguments: Vec<EventArg>,
 }
 
 impl ModuleEventMetadata {
@@ -355,10 +352,10 @@ fn convert_event(
     event: runtime_metadata::EventMetadata,
 ) -> Result<ModuleEventMetadata, Error> {
     let name = convert(event.name)?;
-    let mut arguments = HashSet::new();
+    let mut arguments = Vec::new();
     for arg in convert(event.arguments)? {
         let arg = arg.parse::<EventArg>()?;
-        arguments.insert(arg);
+        arguments.push(arg);
     }
     Ok(ModuleEventMetadata { name, arguments })
 }


### PR DESCRIPTION
Event arguments in the metadata are treated as `Vec` instead of `HashSet`. This fixes an issue with event arguments of the same name.

For example the `Balances::Transfer` event has four arguments: `AccountId` (from), `AccountId` (to), `Balance` (value), `Balance` (fee). Before this change the code would only try to parse the two distinct arguments `AccountId` and `Balance` and decoding would fail.