### PR TITLE
Fix for substrate master

### DIFF
--- a/src/srml/balances.rs
+++ b/src/srml/balances.rs
@@ -20,12 +20,13 @@ use futures::future::{
 };
 use parity_scale_codec::Codec;
 use runtime_primitives::traits::{
-    MaybeSerializeDebug,
+    MaybeSerialize,
     Member,
     SimpleArithmetic,
 };
 use runtime_support::Parameter;
 use substrate_primitives::Pair;
+use std::fmt::Debug;
 
 /// The subset of the `srml_balances::Trait` that a client must implement.
 pub trait Balances: System {
@@ -36,12 +37,13 @@ pub trait Balances: System {
         + Codec
         + Default
         + Copy
-        + MaybeSerializeDebug
+        + MaybeSerialize
+        + Debug
         + From<<Self as System>::BlockNumber>;
 }
 
 /// Blanket impl for using existing runtime types
-impl<T: srml_system::Trait + srml_balances::Trait + std::fmt::Debug> Balances for T
+impl<T: srml_system::Trait + srml_balances::Trait + Debug> Balances for T
 where
     <T as srml_system::Trait>::Header: serde::de::DeserializeOwned,
 {

--- a/src/srml/system.rs
+++ b/src/srml/system.rs
@@ -21,10 +21,9 @@ use runtime_primitives::traits::{
     CheckEqual,
     Hash,
     Header,
-    MaybeDebug,
     MaybeDisplay,
-    MaybeSerializeDebug,
-    MaybeSerializeDebugButNotDeserialize,
+    MaybeSerialize,
+    MaybeSerializeDeserialize,
     Member,
     SimpleArithmetic,
     SimpleBitOps,
@@ -33,14 +32,16 @@ use runtime_primitives::traits::{
 use runtime_support::Parameter;
 use serde::de::DeserializeOwned;
 use substrate_primitives::Pair;
+use std::fmt::Debug;
 
 /// The subset of the `srml_system::Trait` that a client must implement.
-pub trait System: 'static + Eq + Clone + std::fmt::Debug {
+pub trait System: 'static + Eq + Clone + Debug {
     /// Account index (aka nonce) type. This stores the number of previous
     /// transactions associated with a sender account.
     type Index: Parameter
         + Member
-        + MaybeSerializeDebugButNotDeserialize
+        + MaybeSerialize
+        + Debug
         + Default
         + MaybeDisplay
         + SimpleArithmetic
@@ -49,7 +50,8 @@ pub trait System: 'static + Eq + Clone + std::fmt::Debug {
     /// The block number type used by the runtime.
     type BlockNumber: Parameter
         + Member
-        + MaybeSerializeDebug
+        + MaybeSerializeDeserialize
+        + Debug
         + MaybeDisplay
         + SimpleArithmetic
         + Default
@@ -60,7 +62,8 @@ pub trait System: 'static + Eq + Clone + std::fmt::Debug {
     /// The output of the `Hashing` function.
     type Hash: Parameter
         + Member
-        + MaybeSerializeDebug
+        + MaybeSerializeDeserialize
+        + Debug
         + MaybeDisplay
         + SimpleBitOps
         + Default
@@ -76,13 +79,14 @@ pub trait System: 'static + Eq + Clone + std::fmt::Debug {
     /// The user account identifier type for the runtime.
     type AccountId: Parameter
         + Member
-        + MaybeSerializeDebug
+        + MaybeSerialize
+        + Debug
         + MaybeDisplay
         + Ord
         + Default;
 
     /// The address type. This instead of `<srml_system::Trait::Lookup as StaticLookup>::Source`.
-    type Address: Codec + Clone + PartialEq + MaybeDebug;
+    type Address: Codec + Clone + PartialEq + Debug;
 
     /// The block header.
     type Header: Parameter
@@ -91,7 +95,7 @@ pub trait System: 'static + Eq + Clone + std::fmt::Debug {
 }
 
 /// Blanket impl for using existing runtime types
-impl<T: srml_system::Trait + std::fmt::Debug> System for T
+impl<T: srml_system::Trait + Debug> System for T
 where
     <T as srml_system::Trait>::Header: serde::de::DeserializeOwned,
 {


### PR DESCRIPTION
change introduced on master by https://github.com/paritytech/substrate/pull/3821/files

basically Debug is now required in wasm as well but deriving debug in no-std must be made with https://crates.parity.io/substrate_debug_derive/index.html to avoid bloating the wasm blob.