### PR TITLE
update deps for jsonrpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = "0.14.0"
 log = "0.4"
 futures = "0.1.28"
-jsonrpc-core-client = { version = "13.0", features = ["ws"] }
+jsonrpc-core-client = { version = "14.0", features = ["ws"] }
 num-traits = { version = "0.2", default-features = false }
 parity-scale-codec = { version = "1.0", default-features = false, features = ["derive", "full"] }
 runtime_metadata = { git = "https://github.com/paritytech/substrate/", package = "srml-metadata" }


### PR DESCRIPTION
In relation to this: https://github.com/paritytech/substrate/pull/4012

allows subxt to  compile against latest substrate master