### PR TITLE
Fix the module index used to create a encoded func

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "
 substrate-rpc-api = { git = "https://github.com/paritytech/substrate/", package = "sc-rpc-api" }
 substrate-rpc-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-rpc-primitives" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }
-txpool = { git = "https://github.com/paritytech/substrate/", package = "sc-transaction-graph" }
+txpool-api = { git = "https://github.com/paritytech/substrate/", package = "sp-transaction-pool-api" }
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/src/events.rs
+++ b/src/events.rs
@@ -157,7 +157,7 @@ impl<T: System + Balances + 'static> EventsDecoder<T> {
         let mut missing = HashSet::new();
         let mut ignore_set = HashSet::new();
         ignore_set.extend(ignore);
-        for module in self.metadata.modules() {
+        for module in self.metadata.modules_with_events() {
             for event in module.events() {
                 for arg in event.arguments() {
                     for primitive in arg.primitives() {
@@ -220,15 +220,14 @@ impl<T: System + Balances + 'static> EventsDecoder<T> {
             let phase = Phase::decode(input)?;
             let module_variant = input.read_byte()? as u8;
 
-            let module_name = self.metadata.module_name(module_variant)?;
-            let event = if module_name == "System" {
+            let module = self.metadata.module_with_events(module_variant)?;
+            let event = if module.name() == "System" {
                 let system_event = SystemEvent::decode(input)?;
                 RuntimeEvent::System(system_event)
             } else {
                 let event_variant = input.read_byte()? as u8;
-                let module = self.metadata.module(&module_name)?;
                 let event_metadata = module.event(event_variant)?;
-                log::debug!("decoding event '{}::{}'", module_name, event_metadata.name);
+                log::debug!("decoding event '{}::{}'", module.name(), event_metadata.name);
 
                 let mut event_data = Vec::<u8>::new();
                 self.decode_raw_bytes(
@@ -237,7 +236,7 @@ impl<T: System + Balances + 'static> EventsDecoder<T> {
                     &mut event_data,
                 )?;
                 RuntimeEvent::Raw(RawEvent {
-                    module: module_name.clone(),
+                    module: module.name().to_string(),
                     variant: event_metadata.name.clone(),
                     data: event_data,
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ where
         let genesis_hash = self.genesis_hash;
         let call = self
             .metadata()
-            .module(&call.module)
+            .module_with_calls(&call.module)
             .and_then(|module| module.call(&call.function, call.args))?;
 
         log::info!(
@@ -527,7 +527,7 @@ mod tests {
     fn test_chain_read_metadata() {
         let (_, client) = test_setup();
 
-        let balances = client.metadata().module("Balances").unwrap();
+        let balances = client.metadata().module_with_calls("Balances").unwrap();
         let dest = substrate_keyring::AccountKeyring::Bob.to_account_id();
         let address: Address = dest.clone().into();
         let amount: Balance = 10_000;
@@ -541,7 +541,10 @@ mod tests {
         let free_balance =
             <pallet_balances::FreeBalance<node_runtime::Runtime>>::hashed_key_for(&dest);
         let free_balance_key = StorageKey(free_balance);
-        let free_balance_key2 = balances
+        let free_balance_key2 = client
+            .metadata()
+            .module("Balances")
+            .unwrap()
             .storage("FreeBalance")
             .unwrap()
             .get_map::<AccountId, Balance>()


### PR DESCRIPTION
Same as Events, modules with no calls should be ignored when calculating
the module index.