### PR TITLE
Remove pallet crates to improve compilation time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ frame-metadata = { git = "https://github.com/paritytech/substrate/", package = "
 frame-support = { git = "https://github.com/paritytech/substrate/", package = "frame-support" }
 sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime" }
 sp-version = { git = "https://github.com/paritytech/substrate/", package = "sp-version" }
-frame-system = { git = "https://github.com/paritytech/substrate/", package = "frame-system" }
-pallet-balances = { git = "https://github.com/paritytech/substrate/", package = "pallet-balances" }
-pallet-contracts = { git = "https://github.com/paritytech/substrate/", package = "pallet-contracts" }
 pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "pallet-indices" }
 hex = "0.4.0"
 sc-rpc-api = { git = "https://github.com/paritytech/substrate/", package = "sc-rpc-api" }
@@ -38,5 +35,7 @@ sp-transaction-pool = { git = "https://github.com/paritytech/substrate/", packag
 env_logger = "0.7"
 tokio = "0.1"
 wabt = "0.9"
+frame-system = { git = "https://github.com/paritytech/substrate/", package = "frame-system" }
 node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime" }
+pallet-balances = { git = "https://github.com/paritytech/substrate/", package = "pallet-balances" }
 sp-keyring = { git = "https://github.com/paritytech/substrate/", package = "sp-keyring" }

--- a/src/events.rs
+++ b/src/events.rs
@@ -36,8 +36,6 @@ use codec::{
     Output,
 };
 
-use frame_system::Phase;
-
 use crate::{
     frame::balances::Balances,
     metadata::{
@@ -47,6 +45,7 @@ use crate::{
     },
     System,
     SystemEvent,
+    Phase,
 };
 
 /// Top level Event that can be produced by a substrate runtime

--- a/src/frame/balances.rs
+++ b/src/frame/balances.rs
@@ -53,14 +53,6 @@ pub trait Balances: System {
         + From<<Self as System>::BlockNumber>;
 }
 
-/// Blanket impl for using existing runtime types
-impl<T: frame_system::Trait + pallet_balances::Trait + Debug> Balances for T
-where
-    <T as frame_system::Trait>::Header: serde::de::DeserializeOwned,
-{
-    type Balance = T::Balance;
-}
-
 /// The Balances extension trait for the Client.
 pub trait BalancesStore {
     /// Balances type.

--- a/src/frame/system.rs
+++ b/src/frame/system.rs
@@ -37,7 +37,6 @@ use sp_runtime::traits::{
     Member,
     SimpleArithmetic,
     SimpleBitOps,
-    StaticLookup,
 };
 
 use crate::{
@@ -109,20 +108,6 @@ pub trait System: 'static + Eq + Clone + Debug {
         + DeserializeOwned;
 }
 
-/// Blanket impl for using existing runtime types
-impl<T: frame_system::Trait + Debug> System for T
-where
-    <T as frame_system::Trait>::Header: serde::de::DeserializeOwned,
-{
-    type Index = T::Index;
-    type BlockNumber = T::BlockNumber;
-    type Hash = T::Hash;
-    type Hashing = T::Hashing;
-    type AccountId = T::AccountId;
-    type Address = <T::Lookup as StaticLookup>::Source;
-    type Header = T::Header;
-}
-
 /// The System extension trait for the Client.
 pub trait SystemStore {
     /// System type.
@@ -178,4 +163,13 @@ pub enum SystemEvent {
     ExtrinsicSuccess(DispatchInfo),
     /// An extrinsic failed.
     ExtrinsicFailed(sp_runtime::DispatchError, DispatchInfo),
+}
+
+/// A phase of a block's execution.
+#[derive(codec::Decode)]
+pub enum Phase {
+    /// Applying an extrinsic.
+    ApplyExtrinsic(u32),
+    /// The end.
+    Finalization,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ use self::{
         system::{
             System,
             SystemEvent,
+            Phase,
             SystemStore,
         },
     },

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -39,7 +39,6 @@ use jsonrpc_core_client::{
 use num_traits::bounds::Bounded;
 
 use frame_metadata::RuntimeMetadataPrefixed;
-use frame_system::Phase;
 use sc_rpc_api::{
     author::AuthorClient,
     chain::ChainClient,
@@ -77,6 +76,7 @@ use crate::{
     frame::{
         balances::Balances,
         system::{
+            Phase,
             System,
             SystemEvent,
         },


### PR DESCRIPTION
These dependencies were just used to construct a set of runtime types from a supplied runtime implementation. However this significantly increased the compilation time. Removing `balances` and `contracts` halved the build time from ~8min to ~4min.

Note that we still use `indices` for the `Address` type, and also dev dependencies still have these big substrate dependencies.