### PR TITLE
Add FromStr constraint to BlockNumber, bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/src/frame/system.rs
+++ b/src/frame/system.rs
@@ -71,7 +71,8 @@ pub trait System: 'static + Eq + Clone + Debug {
         + Default
         + Bounded
         + Copy
-        + std::hash::Hash;
+        + std::hash::Hash
+        + std::str::FromStr;
 
     /// The output of the `Hashing` function.
     type Hash: Parameter


### PR DESCRIPTION
Fixes compilation error against latest substrate