### PR TITLE
Support Blake2_128Concat key hashing

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -237,6 +237,14 @@ impl<K: Encode, V: Decode + Clone> StorageMap<K, V> {
         let encoded_key = key.encode();
         let hash = match self.hasher {
             StorageHasher::Blake2_128 => sp_core::blake2_128(&encoded_key).to_vec(),
+            StorageHasher::Blake2_128Concat => {
+                // copied from substrate Blake2_128Concat::hash since StorageHasher is not public
+                sp_core::blake2_128(&encoded_key)
+                    .iter()
+                    .chain(&encoded_key)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            },
             StorageHasher::Blake2_256 => sp_core::blake2_256(&encoded_key).to_vec(),
             StorageHasher::Twox128 => sp_core::twox_128(&encoded_key).to_vec(),
             StorageHasher::Twox256 => sp_core::twox_256(&encoded_key).to_vec(),


### PR DESCRIPTION
Implementation copied from https://github.com/paritytech/substrate/blob/6e0a4877afbe2309e106b84333bb70200531b604/frame/support/src/hash.rs#L78 since the StorageHasher trait is not exposed publicly.