### PR TITLE
Generic Extrinsics, storage at hash

### DIFF
--- a/src/frame/balances.rs
+++ b/src/frame/balances.rs
@@ -98,7 +98,7 @@ impl<T: Balances + 'static, S: 'static> BalancesStore for Client<T, S> {
             Ok(map) => map,
             Err(err) => return Box::new(future::err(err)),
         };
-        Box::new(self.fetch_or(map.key(account_id), map.default()))
+        Box::new(self.fetch_or(map.key(account_id), None, map.default()))
     }
 }
 

--- a/src/frame/system.rs
+++ b/src/frame/system.rs
@@ -29,6 +29,7 @@ use frame_support::Parameter;
 use sp_runtime::traits::{
     Bounded,
     CheckEqual,
+    Extrinsic,
     Hash,
     Header,
     MaybeDisplay,
@@ -108,6 +109,9 @@ pub trait System: 'static + Eq + Clone + Debug {
     type Header: Parameter
         + Header<Number = Self::BlockNumber, Hash = Self::Hash>
         + DeserializeOwned;
+
+    /// Extrinsic type within blocks.
+    type Extrinsic: Parameter + Member + Extrinsic + Debug + MaybeSerializeDeserialize;
 }
 
 /// The System extension trait for the Client.
@@ -141,7 +145,7 @@ impl<T: System + Balances + 'static, S: 'static> SystemStore for Client<T, S> {
             Ok(map) => map,
             Err(err) => return Box::new(future::err(err)),
         };
-        Box::new(self.fetch_or(map.key(account_id), map.default()))
+        Box::new(self.fetch_or(map.key(account_id), None, map.default()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,34 +180,37 @@ impl<T: System + Balances + 'static, S: 'static> Client<T, S> {
     pub fn fetch<V: Decode>(
         &self,
         key: StorageKey,
+        hash: Option<T::Hash>,
     ) -> impl Future<Item = Option<V>, Error = Error> {
-        self.connect().and_then(|rpc| rpc.storage::<V>(key))
+        self.connect().and_then(move |rpc| rpc.storage::<V>(key, hash))
     }
 
     /// Fetch a StorageKey or return the default.
     pub fn fetch_or<V: Decode>(
         &self,
         key: StorageKey,
+        hash: Option<T::Hash>,
         default: V,
     ) -> impl Future<Item = V, Error = Error> {
-        self.fetch(key).map(|value| value.unwrap_or(default))
+        self.fetch(key, hash).map(|value| value.unwrap_or(default))
     }
 
     /// Fetch a StorageKey or return the default.
     pub fn fetch_or_default<V: Decode + Default>(
         &self,
         key: StorageKey,
+        hash: Option<T::Hash>,
     ) -> impl Future<Item = V, Error = Error> {
-        self.fetch(key).map(|value| value.unwrap_or_default())
+        self.fetch(key, hash).map(|value| value.unwrap_or_default())
     }
 
     /// Get a block hash. By default returns the latest block hash
     pub fn block_hash(
         &self,
-        hash: Option<BlockNumber<T>>,
+        height: Option<BlockNumber<T>>,
     ) -> impl Future<Item = Option<T::Hash>, Error = Error> {
         self.connect()
-            .and_then(|rpc| rpc.block_hash(hash.map(|h| h)))
+            .and_then(|rpc| rpc.block_hash(height.map(|h| h)))
     }
 
     /// Get a block hash of the latest finalized block

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -61,7 +61,6 @@ use sp_runtime::{
         SignedBlock,
     },
     traits::Hash,
-    OpaqueExtrinsic,
 };
 use sp_transaction_pool::TransactionStatus;
 use sp_version::RuntimeVersion;
@@ -84,7 +83,7 @@ use crate::{
     metadata::Metadata,
 };
 
-pub type ChainBlock<T> = SignedBlock<Block<<T as System>::Header, OpaqueExtrinsic>>;
+pub type ChainBlock<T> = SignedBlock<Block<<T as System>::Header, <T as System>::Extrinsic>>;
 pub type BlockNumber<T> = NumberOrHex<<T as System>::BlockNumber>;
 
 /// Client for substrate rpc interfaces
@@ -110,9 +109,10 @@ impl<T: System> Rpc<T> {
     pub fn storage<V: Decode>(
         &self,
         key: StorageKey,
+        hash: Option<T::Hash>,
     ) -> impl Future<Item = Option<V>, Error = Error> {
         self.state
-            .storage(key, None)
+            .storage(key, hash)
             .map_err(Into::into)
             .and_then(|data| {
                 match data {

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -22,6 +22,7 @@ use sp_runtime::{
         Verify,
     },
     MultiSignature,
+    OpaqueExtrinsic,
 };
 
 use crate::frame::{
@@ -47,6 +48,7 @@ impl System for DefaultNodeRuntime {
     type AccountId = <<MultiSignature as Verify>::Signer as IdentifyAccount>::AccountId;
     type Address = pallet_indices::address::Address<Self::AccountId, u32>;
     type Header = Header<Self::BlockNumber, BlakeTwo256>;
+    type Extrinsic = OpaqueExtrinsic;
 }
 
 impl Balances for DefaultNodeRuntime {


### PR DESCRIPTION
* Generic `Extrinsic` on `System`.
* `Client::storage` takes `Option<T::Hash>` as a second argument.