### PR TITLE
Upgrade to substrate alpha.3 crates.io dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 url = "1.7"
 codec = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive", "full"] }
 
+frame-metadata = { version = "11.0.0-alpha.3", package = "frame-metadata" }
 frame-support = { version = "2.0.0-alpha.3", package = "frame-support" }
 sp-runtime = { version = "2.0.0-alpha.3", package = "sp-runtime" }
 sp-version = { version = "2.0.0-alpha.3", package = "sp-version" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,21 +21,20 @@ serde_json = "1.0"
 url = "1.7"
 codec = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive", "full"] }
 
-frame-metadata = { git = "https://github.com/paritytech/substrate/", package = "frame-metadata" }
-frame-support = { git = "https://github.com/paritytech/substrate/", package = "frame-support" }
-sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime" }
-sp-version = { git = "https://github.com/paritytech/substrate/", package = "sp-version" }
-pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "pallet-indices" }
+frame-support = { version = "2.0.0-alpha.3", package = "frame-support" }
+sp-runtime = { version = "2.0.0-alpha.3", package = "sp-runtime" }
+sp-version = { version = "2.0.0-alpha.3", package = "sp-version" }
+pallet-indices = { version = "2.0.0-alpha.3", package = "pallet-indices" }
 hex = "0.4.0"
-sp-rpc = { git = "https://github.com/paritytech/substrate/", package = "sp-rpc" }
-sp-core = { git = "https://github.com/paritytech/substrate/", package = "sp-core" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate/", package = "sp-transaction-pool" }
+sp-rpc = { version = "2.0.0-alpha.3", package = "sp-rpc" }
+sp-core = { version = "2.0.0-alpha.3", package = "sp-core" }
+sp-transaction-pool = { version = "2.0.0-alpha.3", package = "sp-transaction-pool" }
 
 [dev-dependencies]
 async-std = "1.2.0"
 env_logger = "0.7"
 wabt = "0.9"
-frame-system = { git = "https://github.com/paritytech/substrate/", package = "frame-system" }
+frame-system = { version = "2.0.0-alpha.3", package = "frame-system" }
 node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime" }
-pallet-balances = { git = "https://github.com/paritytech/substrate/", package = "pallet-balances" }
-sp-keyring = { git = "https://github.com/paritytech/substrate/", package = "sp-keyring" }
+pallet-balances = { version = "2.0.0-alpha.3", package = "pallet-balances" }
+sp-keyring = { version = "2.0.0-alpha.3", package = "sp-keyring" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,5 @@ async-std = "1.2.0"
 env_logger = "0.7"
 wabt = "0.9"
 frame-system = { version = "2.0.0-alpha.3", package = "frame-system" }
-node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime" }
 pallet-balances = { version = "2.0.0-alpha.3", package = "pallet-balances" }
 sp-keyring = { version = "2.0.0-alpha.3", package = "sp-keyring" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@
 
 use jsonrpsee::{
     client::RequestError,
-    ws::WsNewDnsError,
+    transport::ws::WsNewDnsError,
 };
 use sp_core::crypto::SecretStringError;
 use sp_runtime::transaction_validity::TransactionValidityError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,35 +593,4 @@ mod tests {
 
         assert!(result.is_ok())
     }
-
-    #[test]
-    #[ignore] // requires locally running substrate node
-    fn test_chain_read_metadata() {
-        let client = async_std::task::block_on(test_client());
-
-        let balances = client.metadata().module_with_calls("Balances").unwrap();
-        let dest = sp_keyring::AccountKeyring::Bob.to_account_id();
-        let address: Address = dest.clone().into();
-        let amount: Balance = 10_000;
-
-        let transfer = pallet_balances::Call::transfer(address.clone(), amount);
-        let call = node_runtime::Call::Balances(transfer);
-        let subxt_transfer = crate::frame::balances::transfer::<Runtime>(address, amount);
-        let call2 = balances.call("transfer", subxt_transfer.args).unwrap();
-        assert_eq!(call.encode().to_vec(), call2.0);
-
-        let account_key =
-            <frame_system::Account<node_runtime::Runtime>>::hashed_key_for(&dest);
-        let account_key_substrate = StorageKey(account_key);
-        let account_key_from_meta = client
-            .metadata()
-            .module("System")
-            .unwrap()
-            .storage("Account")
-            .unwrap()
-            .get_map::<AccountId, pallet_balances::AccountData<Balance>>()
-            .unwrap()
-            .key(dest.clone());
-        assert_eq!(account_key_substrate, account_key_from_meta);
-    }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -28,7 +28,7 @@ use codec::{
 };
 use jsonrpsee::{
     client::Subscription,
-    core::common::{
+    common::{
         to_value as to_json_value,
         Params,
     },
@@ -96,9 +96,9 @@ where
     T: System,
 {
     pub async fn connect_ws(url: &str) -> Result<Self, Error> {
-        let raw_client = jsonrpsee::ws::ws_raw_client(&url).await?;
+        let client = jsonrpsee::ws_client(&url).await?;
         Ok(Rpc {
-            client: raw_client.into(),
+            client: client.into(),
             marker: PhantomData,
         })
     }


### PR DESCRIPTION
Substrate dependencies are now on crates.io, so this PR switches to the released crates. 

Also makes it work with the latest version of jsonrpsee, which is incidentally the only github dependency remaining before we can release to crates.io ourselves.
