### PR TITLE
Add kusama runtime and example

### DIFF
--- a/examples/kusama_balance_transfer.rs
+++ b/examples/kusama_balance_transfer.rs
@@ -1,0 +1,47 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of substrate-subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+use sp_keyring::AccountKeyring;
+use substrate_subxt::{
+    balances,
+    Error,
+    system::System,
+    KusamaRuntime,
+};
+
+fn main() {
+    async_std::task::block_on(async move {
+        env_logger::init();
+
+        let xt_result = transfer_balance().await;
+        match xt_result {
+            Ok(hash) => println!("Balance transfer extrinsic submitted: {}", hash),
+            Err(_) => eprintln!("Balance transfer extrinisic failed"),
+        }
+    });
+}
+
+async fn transfer_balance() -> Result<sp_core::H256, Error> {
+    let signer = AccountKeyring::Alice.pair();
+    let dest = AccountKeyring::Bob.to_account_id();
+
+    // note use of `KusamaRuntime`
+    substrate_subxt::ClientBuilder::<KusamaRuntime>::new()
+        .build().await?
+        .xt(signer, None).await?
+        .submit(balances::transfer::<KusamaRuntime>(dest.clone().into(), 10_000))
+        .await
+}

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -60,3 +60,28 @@ impl Balances for DefaultNodeRuntime {
 }
 
 impl Contracts for DefaultNodeRuntime {}
+
+/// Concrete type definitions compatible with those for kusama, v0.7
+///
+/// # Note
+///
+/// Main difference is `type Address = AccountId`.
+/// Also the contracts module is not part of the kusama runtime.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct KusamaRuntime;
+
+impl System for KusamaRuntime {
+    type Index = u32;
+    type BlockNumber = u32;
+    type Hash = sp_core::H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = <<MultiSignature as Verify>::Signer as IdentifyAccount>::AccountId;
+    type Address = Self::AccountId;
+    type Header = Header<Self::BlockNumber, BlakeTwo256>;
+    type Extrinsic = OpaqueExtrinsic;
+    type AccountData = AccountData<<Self as Balances>::Balance>;
+}
+
+impl Balances for KusamaRuntime {
+    type Balance = u128;
+}


### PR DESCRIPTION
Adds a kusama runtime: it has `type Address = AccountId` and no contracts module. 