### PR TITLE
Raw payload return SignedPayload struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,8 +319,8 @@ where
             .metadata()
             .module_with_calls(&call.module)
             .and_then(|module| module.call(&call.function, call.args))?;
-        let extra = E::new(version, account_nonce, genesis_hash);
-        let raw_payload= SignedPayload::new(call, extra.extra())?;
+        let extra: E = E::new(version, account_nonce, genesis_hash);
+        let raw_payload = SignedPayload::new(call, extra.extra())?;
         Ok(raw_payload)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,13 +303,14 @@ where
     }
 
     /// Creates raw payload to be signed for the supplied `Call` without private key
-    pub async fn create_raw_payload<C>(
+    pub async fn create_raw_payload<C: Encode>(
         &self,
         account_id: <T as System>::AccountId,
         call: Call<C>,
-    ) -> Result<Vec<u8>, Error>
-    where
-        C: codec::Encode,
+    ) -> Result<
+        SignedPayload<Encoded, <E as SignedExtra<T>>::Extra>,
+        Error
+    >
     {
         let account_nonce = self.account(account_id).await?.nonce;
         let version = self.runtime_version.spec_version;
@@ -318,9 +319,9 @@ where
             .metadata()
             .module_with_calls(&call.module)
             .and_then(|module| module.call(&call.function, call.args))?;
-        let extra: E = E::new(version, account_nonce, genesis_hash);
-        let raw_payload = SignedPayload::new(call, extra.extra())?;
-        Ok(raw_payload.encode())
+        let extra = E::new(version, account_nonce, genesis_hash);
+        let raw_payload= SignedPayload::new(call, extra.extra())?;
+        Ok(raw_payload)
     }
 
     /// Create a transaction builder for a private key.
@@ -632,7 +633,7 @@ mod tests {
                 )
                 .await?;
             let raw_signature =
-                signer_pair.sign(raw_payload.encode().split_off(2).as_slice());
+                signer_pair.sign(raw_payload.encode().as_slice());
             let raw_multisig = MultiSignature::from(raw_signature);
 
             // create signature with Xtbuilder


### PR DESCRIPTION
 SignedPayload does not have `decode` implemented, as it is encoded [depending on the length](https://substrate.dev/rustdocs/master/src/sp_runtime/generic/unchecked_extrinsic.rs.html#198). 

Returning the struct allow for different usage, as well as to be signed.