### PR TITLE
Update to substrate alpha.7 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,20 +27,20 @@ serde_json = "1.0"
 url = "2.1"
 codec = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive", "full"] }
 
-frame-metadata = { version = "11.0.0-alpha.6", package = "frame-metadata" }
-frame-support = { version = "2.0.0-alpha.6", package = "frame-support" }
-sp-runtime = { version = "2.0.0-alpha.6", package = "sp-runtime" }
-sp-version = { version = "2.0.0-alpha.6", package = "sp-version" }
-pallet-indices = { version = "2.0.0-alpha.6", package = "pallet-indices" }
+frame-metadata = { version = "11.0.0-alpha.7", package = "frame-metadata" }
+frame-support = { version = "2.0.0-alpha.7", package = "frame-support" }
+sp-runtime = { version = "2.0.0-alpha.7", package = "sp-runtime" }
+sp-version = { version = "2.0.0-alpha.7", package = "sp-version" }
+pallet-indices = { version = "2.0.0-alpha.7", package = "pallet-indices" }
 hex = "0.4.0"
-sp-rpc = { version = "2.0.0-alpha.6", package = "sp-rpc" }
-sp-core = { version = "2.0.0-alpha.6", package = "sp-core" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", package = "sp-transaction-pool" }
+sp-rpc = { version = "2.0.0-alpha.7", package = "sp-rpc" }
+sp-core = { version = "2.0.0-alpha.7", package = "sp-core" }
+sp-transaction-pool = { version = "2.0.0-alpha.7", package = "sp-transaction-pool" }
 
 [dev-dependencies]
 async-std = { version = "1.5.0", features = ["attributes"] }
 env_logger = "0.7"
 wabt = "0.9"
-frame-system = { version = "2.0.0-alpha.6", package = "frame-system" }
-pallet-balances = { version = "2.0.0-alpha.6", package = "pallet-balances" }
-sp-keyring = { version = "2.0.0-alpha.6", package = "sp-keyring" }
+frame-system = { version = "2.0.0-alpha.7", package = "frame-system" }
+pallet-balances = { version = "2.0.0-alpha.7", package = "pallet-balances" }
+sp-keyring = { version = "2.0.0-alpha.7", package = "sp-keyring" }

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -20,11 +20,11 @@ synstructure = "0.12.3"
 async-std = { version = "1.5.0", features = ["attributes"] }
 codec = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive", "full"] }
 env_logger = "0.7.1"
-frame-support = "2.0.0-alpha.6"
+frame-support = "2.0.0-alpha.7"
 pretty_assertions = "0.6.1"
-sp-core = "2.0.0-alpha.6"
-sp-keyring = "2.0.0-alpha.6"
-sp-runtime = "2.0.0-alpha.6"
+sp-core = "2.0.0-alpha.7"
+sp-keyring = "2.0.0-alpha.7"
+sp-runtime = "2.0.0-alpha.7"
 substrate-subxt = { path = ".." }
 trybuild = "1.0.25"
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -95,6 +95,10 @@ impl<T: System> TryFrom<Metadata> for EventsDecoder<T> {
             type_sizes: HashMap::new(),
             marker: PhantomData,
         };
+        // REMOVE when https://github.com/paritytech/substrate-subxt/pull/102 is merged
+        // Balance type will be registered by the proc macro.
+        decoder.register_type_size::<u128>("Balance")?;
+
         // register default event arg type sizes for dynamic decoding of events
         decoder.register_type_size::<bool>("bool")?;
         decoder.register_type_size::<u32>("ReferendumIndex")?;

--- a/src/events.rs
+++ b/src/events.rs
@@ -225,6 +225,12 @@ impl<T: System> EventsDecoder<T> {
                 let event_variant = input.read_byte()?;
                 let event_metadata = module.event(event_variant)?;
 
+                log::debug!(
+                    "received event '{}::{}'",
+                    module.name(),
+                    event_metadata.name
+                );
+
                 let mut event_data = Vec::<u8>::new();
                 self.decode_raw_bytes(
                     &event_metadata.arguments(),
@@ -232,12 +238,7 @@ impl<T: System> EventsDecoder<T> {
                     &mut event_data,
                 )?;
 
-                log::debug!(
-                    "received event '{}::{}', raw bytes: {}",
-                    module.name(),
-                    event_metadata.name,
-                    hex::encode(&event_data),
-                );
+                log::debug!("raw bytes: {}", hex::encode(&event_data),);
 
                 RuntimeEvent::Raw(RawEvent {
                     module: module.name().to_string(),

--- a/src/frame/contracts.rs
+++ b/src/frame/contracts.rs
@@ -41,9 +41,6 @@ pub trait Contracts: System + Balances {}
 /// You can instantiate contracts only with stored code.
 #[derive(Debug, Encode)]
 pub struct PutCodeCall<'a> {
-    /// Gas limit.
-    #[codec(compact)]
-    pub gas_limit: Gas,
     /// Wasm blob.
     pub code: &'a [u8],
 }
@@ -174,7 +171,6 @@ mod tests {
         let result = xt
             .watch()
             .submit(PutCodeCall {
-                gas_limit: 500_000,
                 code: &wasm,
             })
             .await?;

--- a/src/frame/contracts.rs
+++ b/src/frame/contracts.rs
@@ -168,12 +168,7 @@ mod tests {
 
         let xt = client.xt(signer, None).await?;
 
-        let result = xt
-            .watch()
-            .submit(PutCodeCall {
-                code: &wasm,
-            })
-            .await?;
+        let result = xt.watch().submit(PutCodeCall { code: &wasm }).await?;
         let code_hash = result
             .find_event::<CodeStoredEvent<T>>()?
             .ok_or(Error::Other("Failed to find CodeStored event".into()))?
@@ -186,7 +181,7 @@ mod tests {
     #[ignore] // requires locally running substrate node
     fn tx_put_code() {
         env_logger::try_init().ok();
-        let code_hash: Result<_, Error> = async_std::task::block_on(async move {
+        let code_hash_result: Result<_, Error> = async_std::task::block_on(async move {
             let signer = AccountKeyring::Alice.pair();
             let client = test_client().await;
             let code_hash = put_code(&client, signer).await?;
@@ -194,8 +189,11 @@ mod tests {
         });
 
         assert!(
-            code_hash.is_ok(),
-            "Contracts CodeStored event should be received and decoded"
+            code_hash_result.is_ok(),
+            format!(
+                "Error calling put_code and receiving CodeStored Event: {:?}",
+                code_hash_result
+            )
         );
     }
 
@@ -216,7 +214,7 @@ mod tests {
                 .watch()
                 .submit(InstantiateCall {
                     endowment: 100_000_000_000_000,
-                    gas_limit: 500_000,
+                    gas_limit: 500_000_000,
                     code_hash: &code_hash,
                     data: &[],
                 })
@@ -231,7 +229,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Contract should be instantiated successfully"
+            format!("Error instantiating contract: {:?}", result)
         );
     }
 }

--- a/src/frame/system.rs
+++ b/src/frame/system.rs
@@ -184,7 +184,7 @@ pub enum SystemEvent<T: System> {
     /// A new account was created.
     NewAccount(T::AccountId),
     /// An account was reaped.
-    ReapedAccount(T::AccountId),
+    KilledAccount(T::AccountId),
 }
 
 /// A phase of a block's execution.


### PR DESCRIPTION
Updates to latest alpha.7 release, and fixes the contracts tests.

Note that we need to remove the temporary `Balances` type size registration once #102 is merged.