### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
-# Version 0.5.0 (2020-03-25)
+# Version 0.7.0 (2020-05-13)
 
-- First release
-- All substrate dependencies upgraded to `alpha.5`
+* Split subxt [#102](https://github.com/paritytech/substrate-subxt/pull/102)
+* Add support for RPC `state_getReadProof` [#106](https://github.com/paritytech/substrate-subxt/pull/106)
+* Update to substrate alpha.7 release [#105](https://github.com/paritytech/substrate-subxt/pull/105)
+* Double map and plain storage support, introduce macros [#93](https://github.com/paritytech/substrate-subxt/pull/93)
+* Raw payload return SignedPayload struct [#92](https://github.com/paritytech/substrate-subxt/pull/92)
 
 # Version 0.6.0 (2020-04-15)
 
-- Raw extrinsic payloads in Client [#83](https://github.com/paritytech/substrate-subxt/pull/83)
-- Custom extras [#89](https://github.com/paritytech/substrate-subxt/pull/89)
-- Wrap and export BlockNumber [#87](https://github.com/paritytech/substrate-subxt/pull/87)
-- All substrate dependencies upgraded to `alpha.6`
+* Raw extrinsic payloads in Client [#83](https://github.com/paritytech/substrate-subxt/pull/83)
+* Custom extras [#89](https://github.com/paritytech/substrate-subxt/pull/89)
+* Wrap and export BlockNumber [#87](https://github.com/paritytech/substrate-subxt/pull/87)
+* All substrate dependencies upgraded to `alpha.6`
+
+# Version 0.5.0 (2020-03-25)
+
+* First release
+* All substrate dependencies upgraded to `alpha.5`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "proc-macro"]
 
 [package]
 name = "substrate-subxt"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A library to **sub**mit e**xt**rinsics to a [substrate](https://github.com/paritytech/substrate) node via RPC.
 
+## Usage
+
+See [examples](./examples).
+
 **Alternatives**
 
 [substrate-api-client](https://github.com/scs/substrate-api-client) provides similar functionality.
@@ -9,7 +13,7 @@ A library to **sub**mit e**xt**rinsics to a [substrate](https://github.com/parit
 #### License
 
 <sup>
-The entire code within this repository is licensed under the <a href="LICENSE">GPLv3</a>. 
+The entire code within this repository is licensed under the <a href="LICENSE">GPLv3</a>.
 Please <a href="https://www.parity.io/contact/">contact us</a> if you have questions about the licensing of our
  products.
 </sup>


### PR DESCRIPTION
* Split subxt [#102](https://github.com/paritytech/substrate-subxt/pull/102)
* Add support for RPC `state_getReadProof` [#106](https://github.com/paritytech/substrate-subxt/pull/106)
* Update to substrate alpha.7 release [#105](https://github.com/paritytech/substrate-subxt/pull/105)
* Double map and plain storage support, introduce macros [#93](https://github.com/paritytech/substrate-subxt/pull/93)
* Raw payload return SignedPayload struct [#92](https://github.com/paritytech/substrate-subxt/pull/92)