### PR TITLE
Make signing fallable and asynchronous

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-futures = "0.3"
+futures = "0.3.5"
 jsonrpsee = { version = "0.1", features = ["ws"] }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/proc-macro/src/call.rs
+++ b/proc-macro/src/call.rs
@@ -82,6 +82,7 @@ pub fn call(s: Structure) -> TokenStream {
             T: #module + #subxt::system::System + Send + Sync + 'static,
             S: #codec::Encode + Send + Sync + 'static,
             E: #subxt::SignedExtra<T> + #subxt::sp_runtime::traits::SignedExtension + Send + Sync + 'static,
+            <<E as #subxt::SignedExtra<T>>::Extra as #subxt::sp_runtime::traits::SignedExtension>::AdditionalSigned: Send + Sync,
         {
             fn #call<'a>(
                 &'a self,
@@ -154,6 +155,7 @@ mod tests {
                 T: Balances + substrate_subxt::system::System + Send + Sync + 'static,
                 S: codec::Encode + Send + Sync + 'static,
                 E: substrate_subxt::SignedExtra<T> + substrate_subxt::sp_runtime::traits::SignedExtension + Send + Sync + 'static,
+                <<E as substrate_subxt::SignedExtra<T>>::Extra as substrate_subxt::sp_runtime::traits::SignedExtension>::AdditionalSigned: Send + Sync,
             {
                 fn transfer<'a>(
                     &'a self,

--- a/src/frame/balances.rs
+++ b/src/frame/balances.rs
@@ -16,11 +16,21 @@
 
 //! Implements support for the pallet_balances module.
 
-use crate::frame::system::{System, SystemEventsDecoder};
-use codec::{Decode, Encode};
+use crate::frame::system::{
+    System,
+    SystemEventsDecoder,
+};
+use codec::{
+    Decode,
+    Encode,
+};
 use core::marker::PhantomData;
 use frame_support::Parameter;
-use sp_runtime::traits::{AtLeast32Bit, MaybeSerialize, Member};
+use sp_runtime::traits::{
+    AtLeast32Bit,
+    MaybeSerialize,
+    Member,
+};
 use std::fmt::Debug;
 
 /// The subset of the `pallet_balances::Trait` that a client must implement.
@@ -100,7 +110,10 @@ pub struct TransferEvent<T: Balances> {
 mod tests {
     use super::*;
     use crate::{
-        system::{AccountStore, AccountStoreExt},
+        system::{
+            AccountStore,
+            AccountStoreExt,
+        },
         tests::test_client,
     };
     use sp_keyring::AccountKeyring;

--- a/src/frame/balances.rs
+++ b/src/frame/balances.rs
@@ -16,21 +16,11 @@
 
 //! Implements support for the pallet_balances module.
 
-use crate::frame::system::{
-    System,
-    SystemEventsDecoder,
-};
-use codec::{
-    Decode,
-    Encode,
-};
+use crate::frame::system::{System, SystemEventsDecoder};
+use codec::{Decode, Encode};
 use core::marker::PhantomData;
 use frame_support::Parameter;
-use sp_runtime::traits::{
-    AtLeast32Bit,
-    MaybeSerialize,
-    Member,
-};
+use sp_runtime::traits::{AtLeast32Bit, MaybeSerialize, Member};
 use std::fmt::Debug;
 
 /// The subset of the `pallet_balances::Trait` that a client must implement.
@@ -110,10 +100,7 @@ pub struct TransferEvent<T: Balances> {
 mod tests {
     use super::*;
     use crate::{
-        system::{
-            AccountStore,
-            AccountStoreExt,
-        },
+        system::{AccountStore, AccountStoreExt},
         tests::test_client,
     };
     use sp_keyring::AccountKeyring;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,7 @@ pub use sp_core;
 pub use sp_runtime;
 
 use codec::Encode;
-use futures::{
-    future,
-    future::TryFutureExt as _,
-};
+use futures::future;
 use jsonrpsee::client::Subscription;
 use sc_rpc_api::state::ReadProof;
 use sp_core::storage::{
@@ -344,7 +341,8 @@ where
         let unsigned = self
             .create_unsigned(call, signer.account_id(), signer.nonce())
             .await?;
-        signer.sign(unsigned).map_err(From::from).await
+        let signed = signer.sign(unsigned).await?;
+        Ok(signed)
     }
 
     /// Returns an events decoder for a call.

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -144,11 +144,11 @@ where
     > {
         let signature = extrinsic.using_encoded(|payload| self.signer.sign(payload));
         let (call, extra, _) = extrinsic.deconstruct();
-        Box::pin(futures::future::ready(Ok(UncheckedExtrinsic::new_signed(
+        Box::pin(futures::future::ok(UncheckedExtrinsic::new_signed(
             call,
             self.account_id.clone().into(),
             signature.into(),
             extra,
-        ))))
+        )))
     }
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -17,18 +17,34 @@
 //! A library to **sub**mit e**xt**rinsics to a
 //! [substrate](https://github.com/paritytech/substrate) node via RPC.
 
-use crate::{extra::SignedExtra, frame::system::System, Encoded};
+use crate::{
+    extra::SignedExtra,
+    frame::system::System,
+    Encoded,
+};
 use codec::Encode;
 use sp_core::Pair;
 use sp_runtime::{
-    generic::{SignedPayload, UncheckedExtrinsic},
-    traits::{IdentifyAccount, Verify, SignedExtension},
+    generic::{
+        SignedPayload,
+        UncheckedExtrinsic,
+    },
+    traits::{
+        IdentifyAccount,
+        SignedExtension,
+        Verify,
+    },
 };
-use std::{future::Future, marker::PhantomData, pin::Pin};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+};
 
 /// Extrinsic signer.
 pub trait Signer<T: System, S: Encode, E: SignedExtra<T>>
-    where <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync
+where
+    <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync,
 {
     /// Returns the account id.
     fn account_id(&self) -> &T::AccountId;

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -17,27 +17,19 @@
 //! A library to **sub**mit e**xt**rinsics to a
 //! [substrate](https://github.com/paritytech/substrate) node via RPC.
 
-use crate::{
-    extra::SignedExtra,
-    frame::system::System,
-    Encoded,
-};
+use crate::{extra::SignedExtra, frame::system::System, Encoded};
 use codec::Encode;
 use sp_core::Pair;
 use sp_runtime::{
-    generic::{
-        SignedPayload,
-        UncheckedExtrinsic,
-    },
-    traits::{
-        IdentifyAccount,
-        Verify,
-    },
+    generic::{SignedPayload, UncheckedExtrinsic},
+    traits::{IdentifyAccount, Verify, SignedExtension},
 };
-use std::marker::PhantomData;
+use std::{future::Future, marker::PhantomData, pin::Pin};
 
 /// Extrinsic signer.
-pub trait Signer<T: System, S: Encode, E: SignedExtra<T>> {
+pub trait Signer<T: System, S: Encode, E: SignedExtra<T>>
+    where <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync
+{
     /// Returns the account id.
     fn account_id(&self) -> &T::AccountId;
 
@@ -45,10 +37,23 @@ pub trait Signer<T: System, S: Encode, E: SignedExtra<T>> {
     fn nonce(&self) -> Option<T::Index>;
 
     /// Takes an unsigned extrinsic and returns a signed extrinsic.
+    ///
+    /// Some signers may fail, for instance because the hardware on which the keys are located has
+    /// refused the operation.
     fn sign(
         &self,
         extrinsic: SignedPayload<Encoded, E::Extra>,
-    ) -> UncheckedExtrinsic<T::Address, Encoded, S, E::Extra>;
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<
+                        UncheckedExtrinsic<T::Address, Encoded, S, E::Extra>,
+                        String,
+                    >,
+                > + Send
+                + Sync,
+        >,
+    >;
 }
 
 /// Extrinsic signer using a private key.
@@ -91,12 +96,13 @@ where
 
 impl<T, S, E, P> Signer<T, S, E> for PairSigner<T, S, E, P>
 where
-    T: System,
-    T::AccountId: Into<T::Address>,
-    S: Encode,
-    E: SignedExtra<T>,
-    P: Pair,
-    P::Signature: Into<S>,
+    T: System + 'static,
+    T::AccountId: Into<T::Address> + 'static,
+    S: Encode + 'static + Send + Sync,
+    E: SignedExtra<T> + 'static,
+    P: Pair + 'static,
+    P::Signature: Into<S> + 'static,
+    <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync,
 {
     fn account_id(&self) -> &T::AccountId {
         &self.account_id
@@ -109,14 +115,24 @@ where
     fn sign(
         &self,
         extrinsic: SignedPayload<Encoded, E::Extra>,
-    ) -> UncheckedExtrinsic<T::Address, Encoded, S, E::Extra> {
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<
+                        UncheckedExtrinsic<T::Address, Encoded, S, E::Extra>,
+                        String,
+                    >,
+                > + Send
+                + Sync,
+        >,
+    > {
         let signature = extrinsic.using_encoded(|payload| self.signer.sign(payload));
         let (call, extra, _) = extrinsic.deconstruct();
-        UncheckedExtrinsic::new_signed(
+        Box::pin(futures::future::ready(Ok(UncheckedExtrinsic::new_signed(
             call,
             self.account_id.clone().into(),
             signature.into(),
             extra,
-        )
+        ))))
     }
 }


### PR DESCRIPTION
This is needed for hardware wallets, which require human confirmation to
sign transactions.  Blocking on a human to sign transactions is not a
good idea, and the signing might fail for many reasons (device
unplugged, authorization not granted, etc).