### PR TITLE
Improve error handling in proc-macro's.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ client = ["substrate-subxt-client"]
 
 [dependencies]
 log = "0.4.8"
-thiserror = "1.0.19"
+thiserror = "1.0.20"
 futures = "0.3.5"
 jsonrpsee = { version = "0.1.0", features = ["ws"] }
-num-traits = { version = "0.2.11", default-features = false }
-serde = { version = "1.0.111", features = ["derive"] }
-serde_json = "1.0.53"
+num-traits = { version = "0.2.12", default-features = false }
+serde = { version = "1.0.113", features = ["derive"] }
+serde_json = "1.0.55"
 url = "2.1.1"
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"] }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,9 +19,9 @@ jsonrpsee = "0.1.0"
 log = "0.4.8"
 sc-network = { version = "0.8.0-rc3", default-features = false }
 sc-service = { version = "0.8.0-rc3", default-features = false }
-serde_json = "1.0.53"
+serde_json = "1.0.55"
 sp-keyring = "2.0.0-rc3"
-thiserror = "1.0.19"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 async-std = { version = "=1.5.0", features = ["attributes"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -233,6 +233,7 @@ fn start_subxt_client<C: ChainSpec + 'static, S: AbstractService>(
         pruning: Default::default(),
         rpc_cors: Default::default(),
         rpc_http: Default::default(),
+        rpc_ipc: Default::default(),
         rpc_ws: Default::default(),
         rpc_ws_max_connections: Default::default(),
         rpc_methods: Default::default(),

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro2 = "1.0.18"
 proc-macro-crate = "0.1.4"
 proc-macro-error = "1.0.2"
 quote = "1.0.7"
-syn = "1.0.30"
+syn = "1.0.31"
 synstructure = "0.12.4"
 
 [dev-dependencies]
@@ -30,7 +30,7 @@ env_logger = "0.7.1"
 pretty_assertions = "0.6.1"
 sp-keyring = "2.0.0-rc3"
 substrate-subxt = { path = ".." }
-trybuild = "1.0.28"
+trybuild = "1.0.30"
 
 [[test]]
 name = "balances"

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro = true
 heck = "0.3.1"
 proc-macro2 = "1.0.18"
 proc-macro-crate = "0.1.4"
+proc-macro-error = "1.0.2"
 quote = "1.0.7"
 syn = "1.0.30"
 synstructure = "0.12.4"

--- a/proc-macro/src/call.rs
+++ b/proc-macro/src/call.rs
@@ -28,7 +28,6 @@ use synstructure::Structure;
 
 pub fn call(s: Structure) -> TokenStream {
     let subxt = utils::use_crate("substrate-subxt");
-    let codec = utils::use_crate("parity-scale-codec");
     let ident = &s.ast().ident;
     let generics = &s.ast().generics;
     let params = utils::type_params(generics);
@@ -60,32 +59,29 @@ pub fn call(s: Structure) -> TokenStream {
         }
 
         /// Call extension trait.
-        pub trait #call_trait<T: #module, S: #codec::Encode, E: #subxt::SignedExtra<T>> {
+        pub trait #call_trait<T: #subxt::Runtime + #module> {
             /// Create and submit an extrinsic.
             fn #call<'a>(
                 &'a self,
-                signer: &'a (dyn #subxt::Signer<T, S, E> + Send + Sync),
+                signer: &'a (dyn #subxt::Signer<T> + Send + Sync),
                 #args
             ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<T::Hash, #subxt::Error>> + Send + 'a>>;
 
             /// Create, submit and watch an extrinsic.
             fn #call_and_watch<'a>(
                 &'a self,
-                signer: &'a (dyn #subxt::Signer<T, S, E> + Send + Sync),
+                signer: &'a (dyn #subxt::Signer<T> + Send + Sync),
                 #args
             ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<#subxt::ExtrinsicSuccess<T>, #subxt::Error>> + Send + 'a>>;
         }
 
-        impl<T, S, E> #call_trait<T, S, E> for #subxt::Client<T, S, E>
+        impl<T: #subxt::Runtime + #module> #call_trait<T> for #subxt::Client<T>
         where
-            T: #module + #subxt::system::System + Send + Sync + 'static,
-            S: #codec::Encode + Send + Sync + 'static,
-            E: #subxt::SignedExtra<T> + #subxt::sp_runtime::traits::SignedExtension + Send + Sync + 'static,
-            <<E as #subxt::SignedExtra<T>>::Extra as #subxt::sp_runtime::traits::SignedExtension>::AdditionalSigned: Send + Sync,
+            <<T::Extra as #subxt::SignedExtra<T>>::Extra as #subxt::SignedExtension>::AdditionalSigned: Send + Sync,
         {
             fn #call<'a>(
                 &'a self,
-                signer: &'a (dyn #subxt::Signer<T, S, E> + Send + Sync),
+                signer: &'a (dyn #subxt::Signer<T> + Send + Sync),
                 #args
             ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<T::Hash, #subxt::Error>> + Send + 'a>> {
                 let #marker = core::marker::PhantomData::<T>;
@@ -94,7 +90,7 @@ pub fn call(s: Structure) -> TokenStream {
 
             fn #call_and_watch<'a>(
                 &'a self,
-                signer: &'a (dyn #subxt::Signer<T, S, E> + Send + Sync),
+                signer: &'a (dyn #subxt::Signer<T> + Send + Sync),
                 #args
             ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<#subxt::ExtrinsicSuccess<T>, #subxt::Error>> + Send + 'a>> {
                 let #marker = core::marker::PhantomData::<T>;
@@ -130,11 +126,11 @@ mod tests {
             }
 
             /// Call extension trait.
-            pub trait TransferCallExt<T: Balances, S: codec::Encode, E: substrate_subxt::SignedExtra<T>> {
+            pub trait TransferCallExt<T: substrate_subxt::Runtime + Balances> {
                 /// Create and submit an extrinsic.
                 fn transfer<'a>(
                     &'a self,
-                    signer: &'a (dyn substrate_subxt::Signer<T, S, E> + Send + Sync),
+                    signer: &'a (dyn substrate_subxt::Signer<T> + Send + Sync),
                     to: &'a <T as System>::Address,
                     amount: T::Balance,
                 ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<T::Hash, substrate_subxt::Error>> + Send + 'a>>;
@@ -142,22 +138,19 @@ mod tests {
                 /// Create, submit and watch an extrinsic.
                 fn transfer_and_watch<'a>(
                     &'a self,
-                    signer: &'a (dyn substrate_subxt::Signer<T, S, E> + Send + Sync),
+                    signer: &'a (dyn substrate_subxt::Signer<T> + Send + Sync),
                     to: &'a <T as System>::Address,
                     amount: T::Balance,
                 ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<substrate_subxt::ExtrinsicSuccess<T>, substrate_subxt::Error>> + Send + 'a>>;
             }
 
-            impl<T, S, E> TransferCallExt<T, S, E> for substrate_subxt::Client<T, S, E>
+            impl<T: substrate_subxt::Runtime + Balances> TransferCallExt<T> for substrate_subxt::Client<T>
             where
-                T: Balances + substrate_subxt::system::System + Send + Sync + 'static,
-                S: codec::Encode + Send + Sync + 'static,
-                E: substrate_subxt::SignedExtra<T> + substrate_subxt::sp_runtime::traits::SignedExtension + Send + Sync + 'static,
-                <<E as substrate_subxt::SignedExtra<T>>::Extra as substrate_subxt::sp_runtime::traits::SignedExtension>::AdditionalSigned: Send + Sync,
+                <T::Extra as substrate_subxt::SignedExtra<T>>::AdditionalSigned: Send + Sync,
             {
                 fn transfer<'a>(
                     &'a self,
-                    signer: &'a (dyn substrate_subxt::Signer<T, S, E> + Send + Sync),
+                    signer: &'a (dyn substrate_subxt::Signer<T> + Send + Sync),
                     to: &'a <T as System>::Address,
                     amount: T::Balance,
                 ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<T::Hash, substrate_subxt::Error>> + Send + 'a>> {
@@ -167,7 +160,7 @@ mod tests {
 
                 fn transfer_and_watch<'a>(
                     &'a self,
-                    signer: &'a (dyn substrate_subxt::Signer<T, S, E> + Send + Sync),
+                    signer: &'a (dyn substrate_subxt::Signer<T> + Send + Sync),
                     to: &'a <T as System>::Address,
                     amount: T::Balance,
                 ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<substrate_subxt::ExtrinsicSuccess<T>, substrate_subxt::Error>> + Send + 'a>> {

--- a/proc-macro/src/call.rs
+++ b/proc-macro/src/call.rs
@@ -146,7 +146,7 @@ mod tests {
 
             impl<T: substrate_subxt::Runtime + Balances> TransferCallExt<T> for substrate_subxt::Client<T>
             where
-                <T::Extra as substrate_subxt::SignedExtra<T>>::AdditionalSigned: Send + Sync,
+                <<T::Extra as substrate_subxt::SignedExtra<T>>::Extra as substrate_subxt::SignedExtension>::AdditionalSigned: Send + Sync,
             {
                 fn transfer<'a>(
                     &'a self,

--- a/proc-macro/src/event.rs
+++ b/proc-macro/src/event.rs
@@ -36,7 +36,7 @@ pub fn event(s: Structure) -> TokenStream {
     let event = format_ident!("{}", event_name.to_snake_case());
     let event_trait = format_ident!("{}EventExt", event_name);
 
-    let expanded = quote! {
+    quote! {
         impl<T: #module> #subxt::Event<T> for #ident<T> {
             const MODULE: &'static str = MODULE;
             const EVENT: &'static str = #event_name;
@@ -53,9 +53,7 @@ pub fn event(s: Structure) -> TokenStream {
                 self.find_event()
             }
         }
-    };
-
-    TokenStream::from(expanded)
+    }
 }
 
 #[cfg(test)]

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -24,32 +24,35 @@ mod test;
 mod utils;
 
 use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
 use synstructure::{
     decl_derive,
     Structure,
 };
 
 #[proc_macro_attribute]
+#[proc_macro_error]
 pub fn module(args: TokenStream, input: TokenStream) -> TokenStream {
     module::module(args.into(), input.into()).into()
 }
 
-decl_derive!([Call] => call);
+decl_derive!([Call] => #[proc_macro_error] call);
 fn call(s: Structure) -> TokenStream {
     call::call(s).into()
 }
 
-decl_derive!([Event] => event);
+decl_derive!([Event] => #[proc_macro_error] event);
 fn event(s: Structure) -> TokenStream {
     event::event(s).into()
 }
 
-decl_derive!([Store, attributes(store)] => store);
+decl_derive!([Store, attributes(store)] => #[proc_macro_error] store);
 fn store(s: Structure) -> TokenStream {
     store::store(s).into()
 }
 
 #[proc_macro]
+#[proc_macro_error]
 pub fn subxt_test(input: TokenStream) -> TokenStream {
     test::test(input.into()).into()
 }

--- a/proc-macro/src/module.rs
+++ b/proc-macro/src/module.rs
@@ -49,7 +49,7 @@ type ModuleAttrs = utils::Attrs<ModuleAttr>;
 fn ignore(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
         if let Some(ident) = attr.path.get_ident() {
-            if ident.to_string() == "module" {
+            if ident == "module" {
                 let attrs: ModuleAttrs = syn::parse2(attr.tokens.clone())
                     .map_err(|err| abort!("{}", err))
                     .unwrap();
@@ -72,11 +72,11 @@ fn with_module_ident(module: &syn::Ident) -> syn::Ident {
 
 pub fn module(_args: TokenStream, tokens: TokenStream) -> TokenStream {
     let input: Result<syn::ItemTrait, _> = syn::parse2(tokens.clone());
-    // handle #[module(ignore)] by just returning the tokens
-    let input = if input.is_err() {
-        return tokens
+    let input = if let Ok(input) = input {
+        input
     } else {
-        input.unwrap()
+        // handle #[module(ignore)] by just returning the tokens
+        return tokens
     };
 
     let subxt = utils::use_crate("substrate-subxt");

--- a/proc-macro/src/store.rs
+++ b/proc-macro/src/store.rs
@@ -20,6 +20,7 @@ use heck::{
     SnakeCase,
 };
 use proc_macro2::TokenStream;
+use proc_macro_error::abort;
 use quote::{
     format_ident,
     quote,
@@ -50,7 +51,9 @@ impl Parse for StoreAttr {
 type StoreAttrs = utils::Attrs<StoreAttr>;
 
 fn parse_returns_attr(attr: &syn::Attribute) -> Option<(syn::Type, syn::Type, bool)> {
-    let attrs: StoreAttrs = syn::parse2(attr.tokens.clone()).unwrap();
+    let attrs: StoreAttrs = syn::parse2(attr.tokens.clone())
+        .map_err(|err| abort!("{}", err))
+        .unwrap();
     attrs.attrs.into_iter().next().map(|attr| {
         let StoreAttr::Returns(attr) = attr;
         let ty = attr.value;
@@ -81,7 +84,9 @@ pub fn store(s: Structure) -> TokenStream {
         .iter()
         .filter_map(|bi| bi.ast().attrs.iter().filter_map(parse_returns_attr).next())
         .next()
-        .expect("#[store(returns = ..)] needs to be specified.");
+        .unwrap_or_else(|| {
+            abort!(ident, "#[store(returns = ..)] needs to be specified.")
+        });
     let fetch = if uses_default {
         quote!(fetch_or_default)
     } else {
@@ -93,7 +98,13 @@ pub fn store(s: Structure) -> TokenStream {
             0 => "plain",
             1 => "map",
             2 => "double_map",
-            _ => panic!("invalid number of arguments"),
+            _ => {
+                abort!(
+                    ident,
+                    "Expected 0-2 fields but found {}",
+                    filtered_fields.len()
+                );
+            }
         }
     );
     let keys = filtered_fields

--- a/proc-macro/src/store.rs
+++ b/proc-macro/src/store.rs
@@ -138,12 +138,7 @@ pub fn store(s: Structure) -> TokenStream {
             ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<#ret, #subxt::Error>> + Send + 'a>>;
         }
 
-        impl<T, S, E> #store_trait<T> for #subxt::Client<T, S, E>
-        where
-            T: #module + Send + Sync,
-            S: 'static,
-            E: Send + Sync + 'static,
-        {
+        impl<T: #subxt::Runtime + #module> #store_trait<T> for #subxt::Client<T> {
             fn #store<'a>(
                 &'a self,
                 #args
@@ -196,12 +191,7 @@ mod tests {
                 ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Result<AccountData<T::Balance>, substrate_subxt::Error>> + Send + 'a>>;
             }
 
-            impl<T, S, E> AccountStoreExt<T> for substrate_subxt::Client<T, S, E>
-            where
-                T: Balances + Send + Sync,
-                S: 'static,
-                E: Send + Sync + 'static,
-            {
+            impl<T: substrate_subxt::Runtime + Balances> AccountStoreExt<T> for substrate_subxt::Client<T> {
                 fn account<'a>(
                     &'a self,
                     account_id: &'a <T as System>::AccountId,

--- a/proc-macro/src/test.rs
+++ b/proc-macro/src/test.rs
@@ -429,9 +429,7 @@ mod tests {
             #[ignore]
             async fn test_transfer_balance() {
                 env_logger::try_init().ok();
-                let client = substrate_subxt::ClientBuilder::<
-                    KusamaRuntime,
-                >::new().build().await.unwrap();
+                let client = substrate_subxt::ClientBuilder::<KusamaRuntime>::new().build().await.unwrap();
                 let signer = substrate_subxt::PairSigner::new(sp_keyring::AccountKeyring::Alice.pair());
                 #[allow(unused)]
                 let alice = sp_keyring::AccountKeyring::Alice.to_account_id();

--- a/proc-macro/src/test.rs
+++ b/proc-macro/src/test.rs
@@ -69,10 +69,9 @@ struct Items<I> {
 impl<I: Parse> Parse for Items<I> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let content;
-        Ok(Self {
-            brace: syn::braced!(content in input),
-            items: content.parse_terminated(I::parse)?,
-        })
+        let brace = syn::braced!(content in input);
+        let items = content.parse_terminated(I::parse)?;
+        Ok(Self { brace, items })
     }
 }
 
@@ -81,7 +80,7 @@ type ItemTest = Items<TestItem>;
 #[derive(Debug)]
 enum TestItem {
     Name(Item<kw::name, syn::Ident>),
-    Runtime(Item<kw::runtime, syn::Type>),
+    Runtime(Item<kw::runtime, Box<syn::Type>>),
     Account(Item<kw::account, syn::Ident>),
     State(Item<kw::state, ItemState>),
     Prelude(Item<kw::prelude, syn::Block>),
@@ -135,7 +134,7 @@ type StateItem = Item<syn::Ident, syn::Expr>;
 
 struct Test {
     name: syn::Ident,
-    runtime: syn::Type,
+    runtime: Box<syn::Type>,
     account: syn::Ident,
     state: Option<State>,
     prelude: Option<syn::Block>,
@@ -382,7 +381,7 @@ impl From<ItemState> for State {
 
 fn struct_name(expr: &syn::Expr) -> syn::Path {
     if let syn::Expr::Struct(syn::ExprStruct { path, .. }) = expr {
-        return path.clone()
+        path.clone()
     } else {
         abort!(expr, "Expected a struct");
     }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -22,9 +22,9 @@ use core::{
     fmt::Debug,
     marker::PhantomData,
 };
-use sp_runtime::traits::SignedExtension;
 use sp_runtime::{
     generic::Era,
+    traits::SignedExtension,
     transaction_validity::TransactionValidityError,
 };
 

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -22,9 +22,9 @@ use core::{
     fmt::Debug,
     marker::PhantomData,
 };
+pub use sp_runtime::traits::SignedExtension;
 use sp_runtime::{
     generic::Era,
-    traits::SignedExtension,
     transaction_validity::TransactionValidityError,
 };
 
@@ -222,9 +222,9 @@ where
 }
 
 /// Trait for implementing transaction extras for a runtime.
-pub trait SignedExtra<T: System> {
+pub trait SignedExtra<T: System>: SignedExtension {
     /// The type the extras.
-    type Extra: SignedExtension;
+    type Extra: SignedExtension + Send + Sync;
 
     /// Creates a new `SignedExtra`.
     fn new(

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -22,7 +22,7 @@ use core::{
     fmt::Debug,
     marker::PhantomData,
 };
-pub use sp_runtime::traits::SignedExtension;
+use sp_runtime::traits::SignedExtension;
 use sp_runtime::{
     generic::Era,
     transaction_validity::TransactionValidityError,

--- a/src/frame/balances.rs
+++ b/src/frame/balances.rs
@@ -110,36 +110,52 @@ pub struct TransferEvent<T: Balances> {
 mod tests {
     use super::*;
     use crate::{
-        system::{
-            AccountStore,
-            AccountStoreExt,
+        signer::{
+            PairSigner,
+            Signer,
         },
-        tests::test_client,
+        system::AccountStoreExt,
+        tests::{
+            test_client,
+            TestRuntime,
+        },
+    };
+    use sp_core::{
+        sr25519::Pair,
+        Pair as _,
     };
     use sp_keyring::AccountKeyring;
 
-    subxt_test!({
-        name: test_transfer,
-        step: {
-            state: {
-                alice: AccountStore { account_id: &alice },
-                bob: AccountStore { account_id: &bob },
-            },
-            call: TransferCall {
-                to: &bob.clone().into(),
-                amount: 10_000,
-            },
-            event: TransferEvent {
-                from: alice.clone(),
-                to: bob.clone(),
-                amount: 10_000,
-            },
-            assert: {
-                assert!(pre.alice.data.free - 10_000 >= post.alice.data.free);
-                assert_eq!(pre.bob.data.free + 10_000, post.bob.data.free);
-            },
-        },
-    });
+    #[async_std::test]
+    async fn test_transfer() {
+        env_logger::try_init().ok();
+        let alice = PairSigner::<TestRuntime, _>::new(AccountKeyring::Alice.pair());
+        let bob = PairSigner::<TestRuntime, _>::new(AccountKeyring::Bob.pair());
+        let (client, _) = test_client().await;
+
+        let alice_pre = client.account(alice.account_id(), None).await.unwrap();
+        let bob_pre = client.account(bob.account_id(), None).await.unwrap();
+
+        let event = client
+            .transfer_and_watch(&alice, &bob.account_id(), 10_000)
+            .await
+            .unwrap()
+            .transfer()
+            .unwrap()
+            .unwrap();
+        let expected_event = TransferEvent {
+            from: alice.account_id().clone(),
+            to: bob.account_id().clone(),
+            amount: 10_000,
+        };
+        assert_eq!(event, expected_event);
+
+        let alice_post = client.account(alice.account_id(), None).await.unwrap();
+        let bob_post = client.account(bob.account_id(), None).await.unwrap();
+
+        assert!(alice_pre.data.free - 10_000 >= alice_post.data.free);
+        assert_eq!(bob_pre.data.free + 10_000, bob_post.data.free);
+    }
 
     #[async_std::test]
     async fn test_state_total_issuance() {
@@ -156,5 +172,25 @@ mod tests {
         let account = AccountKeyring::Alice.to_account_id();
         let info = client.account(&account, None).await.unwrap();
         assert_ne!(info.data.free, 0);
+    }
+
+    #[async_std::test]
+    async fn test_transfer_error() {
+        env_logger::try_init().ok();
+        let alice = PairSigner::new(AccountKeyring::Alice.pair());
+        let hans = PairSigner::new(Pair::generate().0);
+        let (client, _) = test_client().await;
+        let res = client
+            .transfer_and_watch(&alice, hans.account_id(), 100_000_000_000)
+            .await
+            .unwrap();
+        println!("{:?}", res);
+        let res = client
+            .transfer_and_watch(&hans, alice.account_id(), 100_000_000_000)
+            .await
+            .unwrap();
+
+        println!("{:?}", res);
+        assert!(false);
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -31,6 +31,7 @@ use sp_core::storage::StorageKey;
 
 pub mod balances;
 pub mod contracts;
+pub mod sudo;
 pub mod system;
 
 /// Store trait.

--- a/src/frame/sudo.rs
+++ b/src/frame/sudo.rs
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of substrate-subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Implements support for the frame_sudo module.
+
+use crate::{
+    frame::system::{
+        System,
+        SystemEventsDecoder,
+    },
+    Encoded,
+};
+use codec::Encode;
+use core::marker::PhantomData;
+
+/// The subset of the `frame_sudo::Trait` that a client must implement.
+#[module]
+pub trait Sudo: System {}
+
+/// Execute a transaction with sudo permissions.
+#[derive(Clone, Debug, Eq, PartialEq, Call, Encode)]
+pub struct SudoCall<'a, T: Sudo> {
+    /// Runtime marker.
+    pub _runtime: PhantomData<T>,
+    /// Encoded transaction.
+    pub call: &'a Encoded,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::balances::TransferCall;
+
+    subxt_test!({
+        name: test_sudo,
+        step: {
+            call: SudoCall {
+                _runtime: PhantomData,
+                call: &client.encode(
+                    TransferCall {
+                        to: &bob.clone().into(),
+                        amount: 10_000,
+                    }
+                ).unwrap(),
+            },
+        }
+    });
+}

--- a/src/frame/system.rs
+++ b/src/frame/system.rs
@@ -155,21 +155,6 @@ pub struct SetCodeCall<'a, T: System> {
     pub code: &'a [u8],
 }
 
-/// Event for the System module.
-#[derive(Clone, Debug, Eq, PartialEq, Decode)]
-pub enum SystemEvent<T: System> {
-    /// An extrinsic completed successfully.
-    ExtrinsicSuccess(DispatchInfo),
-    /// An extrinsic failed.
-    ExtrinsicFailed(DispatchError, DispatchInfo),
-    /// `:code` was updated.
-    CodeUpdated,
-    /// A new account was created.
-    NewAccount(T::AccountId),
-    /// An account was reaped.
-    KilledAccount(T::AccountId),
-}
-
 /// A phase of a block's execution.
 #[derive(Clone, Debug, Eq, PartialEq, Decode)]
 pub enum Phase {
@@ -177,4 +162,45 @@ pub enum Phase {
     ApplyExtrinsic(u32),
     /// The end.
     Finalization,
+}
+
+/// An extrinsic completed successfully.
+#[derive(Clone, Debug, Eq, PartialEq, Event, Decode)]
+pub struct ExtrinsicSuccessEvent<T: System> {
+    /// Runtime marker.
+    pub _runtime: PhantomData<T>,
+    /// The dispatch info.
+    pub info: DispatchInfo,
+}
+
+/// An extrinsic failed.
+#[derive(Clone, Debug, Eq, PartialEq, Event, Decode)]
+pub struct ExtrinsicFailedEvent<T: System> {
+    /// Runtime marker.
+    pub _runtime: PhantomData<T>,
+    /// The dispatch error.
+    pub error: DispatchError,
+    /// The dispatch info.
+    pub info: DispatchInfo,
+}
+
+/// `:code` was updated.
+#[derive(Clone, Debug, Eq, PartialEq, Event, Decode)]
+pub struct CodeUpdatedEvent<T: System> {
+    /// Runtime marker.
+    pub _runtime: PhantomData<T>,
+}
+
+/// A new account was created.
+#[derive(Clone, Debug, Eq, PartialEq, Event, Decode)]
+pub struct NewAccountEvent<T: System> {
+    /// Created account id.
+    pub account: T::AccountId,
+}
+
+/// An account was reaped.
+#[derive(Clone, Debug, Eq, PartialEq, Event, Decode)]
+pub struct KilledAccountEvent<T: System> {
+    /// Killed account id.
+    pub account: T::AccountId,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,7 @@ pub use substrate_subxt_client as client;
 pub use sp_core;
 pub use sp_runtime;
 
-use codec::{
-    Decode,
-    Encode,
-};
+use codec::Decode;
 use futures::future;
 use jsonrpsee::client::Subscription;
 use sc_rpc_api::state::ReadProof;
@@ -59,14 +56,7 @@ use sp_core::storage::{
     StorageChangeSet,
     StorageKey,
 };
-use sp_runtime::{
-    generic::{
-        SignedPayload,
-        UncheckedExtrinsic,
-    },
-    traits::SignedExtension,
-    MultiSignature,
-};
+use sp_runtime::traits::SignedExtension;
 use sp_version::RuntimeVersion;
 use std::marker::PhantomData;
 
@@ -115,13 +105,13 @@ use crate::{
 
 /// ClientBuilder for constructing a Client.
 #[derive(Default)]
-pub struct ClientBuilder<T: System, S = MultiSignature, E = DefaultExtra<T>> {
-    _marker: std::marker::PhantomData<(T, S, E)>,
+pub struct ClientBuilder<T: Runtime> {
+    _marker: std::marker::PhantomData<T>,
     url: Option<String>,
     client: Option<jsonrpsee::Client>,
 }
 
-impl<T: System + Send + Sync, S, E> ClientBuilder<T, S, E> {
+impl<T: Runtime> ClientBuilder<T> {
     /// Creates a new ClientBuilder.
     pub fn new() -> Self {
         Self {
@@ -144,7 +134,7 @@ impl<T: System + Send + Sync, S, E> ClientBuilder<T, S, E> {
     }
 
     /// Creates a new Client.
-    pub async fn build(self) -> Result<Client<T, S, E>, Error> {
+    pub async fn build(self) -> Result<Client<T>, Error> {
         let client = if let Some(client) = self.client {
             client
         } else {
@@ -173,15 +163,15 @@ impl<T: System + Send + Sync, S, E> ClientBuilder<T, S, E> {
 }
 
 /// Client to interface with a substrate node.
-pub struct Client<T: System, S = MultiSignature, E = DefaultExtra<T>> {
+pub struct Client<T: Runtime> {
     rpc: Rpc<T>,
     genesis_hash: T::Hash,
     metadata: Metadata,
     runtime_version: RuntimeVersion,
-    _marker: PhantomData<(fn() -> S, E)>,
+    _marker: PhantomData<(fn() -> T::Signature, T::Extra)>,
 }
 
-impl<T: System, S, E> Clone for Client<T, S, E> {
+impl<T: Runtime> Clone for Client<T> {
     fn clone(&self) -> Self {
         Self {
             rpc: self.rpc.clone(),
@@ -193,7 +183,7 @@ impl<T: System, S, E> Clone for Client<T, S, E> {
     }
 }
 
-impl<T: System, S, E> Client<T, S, E> {
+impl<T: Runtime> Client<T> {
     /// Returns the genesis hash.
     pub fn genesis(&self) -> &T::Hash {
         &self.genesis_hash
@@ -309,14 +299,7 @@ impl<T: System, S, E> Client<T, S, E> {
         let headers = self.rpc.subscribe_finalized_blocks().await?;
         Ok(headers)
     }
-}
 
-impl<T, S, E> Client<T, S, E>
-where
-    T: System + Send + Sync + 'static,
-    S: Encode + Send + Sync + 'static,
-    E: SignedExtra<T> + SignedExtension + Send + Sync + 'static,
-{
     /// Creates an unsigned extrinsic.
     ///
     /// If `nonce` is `None` the nonce will be fetched from the chain.
@@ -325,7 +308,11 @@ where
         call: C,
         account_id: &<T as System>::AccountId,
         nonce: Option<T::Index>,
-    ) -> Result<SignedPayload<Encoded, <E as SignedExtra<T>>::Extra>, Error> {
+    ) -> Result<SignedPayload<T>, Error>
+    where
+        <<T::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned:
+            Send + Sync,
+    {
         let account_nonce = if let Some(nonce) = nonce {
             nonce
         } else {
@@ -338,8 +325,9 @@ where
             .metadata()
             .module_with_calls(C::MODULE)
             .and_then(|module| module.call(C::FUNCTION, call))?;
-        let extra: E = E::new(spec_version, tx_version, account_nonce, genesis_hash);
-        let raw_payload = SignedPayload::new(call, extra.extra())?;
+        let extra: T::Extra =
+            T::Extra::new(spec_version, tx_version, account_nonce, genesis_hash);
+        let raw_payload = SignedPayload::<T>::new(call, extra.extra())?;
         Ok(raw_payload)
     }
 
@@ -347,13 +335,11 @@ where
     pub async fn create_signed<C: Call<T> + Send + Sync>(
         &self,
         call: C,
-        signer: &(dyn Signer<T, S, E> + Send + Sync),
-    ) -> Result<
-        UncheckedExtrinsic<T::Address, Encoded, S, <E as SignedExtra<T>>::Extra>,
-        Error,
-    >
+        signer: &(dyn Signer<T> + Send + Sync),
+    ) -> Result<UncheckedExtrinsic<T>, Error>
     where
-        <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync,
+        <<T::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned:
+            Send + Sync,
     {
         let unsigned = self
             .create_unsigned(call, signer.account_id(), signer.nonce())
@@ -373,12 +359,7 @@ where
     /// Create and submit an extrinsic and return corresponding Hash if successful
     pub async fn submit_extrinsic(
         &self,
-        extrinsic: UncheckedExtrinsic<
-            T::Address,
-            Encoded,
-            S,
-            <E as SignedExtra<T>>::Extra,
-        >,
+        extrinsic: UncheckedExtrinsic<T>,
     ) -> Result<T::Hash, Error> {
         self.rpc.submit_extrinsic(extrinsic).await
     }
@@ -386,12 +367,7 @@ where
     /// Create and submit an extrinsic and return corresponding Event if successful
     pub async fn submit_and_watch_extrinsic(
         &self,
-        extrinsic: UncheckedExtrinsic<
-            T::Address,
-            Encoded,
-            S,
-            <E as SignedExtra<T>>::Extra,
-        >,
+        extrinsic: UncheckedExtrinsic<T>,
         decoder: EventsDecoder<T>,
     ) -> Result<ExtrinsicSuccess<T>, Error> {
         self.rpc
@@ -403,10 +379,11 @@ where
     pub async fn submit<C: Call<T> + Send + Sync>(
         &self,
         call: C,
-        signer: &(dyn Signer<T, S, E> + Send + Sync),
+        signer: &(dyn Signer<T> + Send + Sync),
     ) -> Result<T::Hash, Error>
     where
-        <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync,
+        <<T::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned:
+            Send + Sync,
     {
         let extrinsic = self.create_signed(call, signer).await?;
         self.submit_extrinsic(extrinsic).await
@@ -416,10 +393,11 @@ where
     pub async fn watch<C: Call<T> + Send + Sync>(
         &self,
         call: C,
-        signer: &(dyn Signer<T, S, E> + Send + Sync),
+        signer: &(dyn Signer<T> + Send + Sync),
     ) -> Result<ExtrinsicSuccess<T>, Error>
     where
-        <<E as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync,
+        <<T::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned:
+            Send + Sync,
     {
         let extrinsic = self.create_signed(call, signer).await?;
         let decoder = self.events_decoder::<C>();
@@ -441,6 +419,7 @@ impl codec::Encode for Encoded {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codec::Encode;
     use sp_core::{
         storage::{
             well_known_keys,
@@ -452,6 +431,7 @@ mod tests {
         AccountKeyring,
         Ed25519Keyring,
     };
+    use sp_runtime::MultiSignature;
     use substrate_subxt_client::{
         DatabaseConfig,
         Role,
@@ -460,7 +440,9 @@ mod tests {
     };
     use tempdir::TempDir;
 
-    pub(crate) async fn test_client() -> (Client<crate::NodeTemplateRuntime>, TempDir) {
+    pub(crate) type TestRuntime = crate::NodeTemplateRuntime;
+
+    pub(crate) async fn test_client() -> (Client<TestRuntime>, TempDir) {
         let tmp = TempDir::new("subxt-").expect("failed to create tempdir");
         let config = SubxtClientConfig {
             impl_name: "substrate-subxt-full-client",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,6 @@ pub use crate::{
     error::Error,
     events::{
         EventsDecoder,
-        EventsError,
         RawEvent,
     },
     extra::*,
@@ -95,7 +94,6 @@ use crate::{
         AccountStoreExt,
         Phase,
         System,
-        SystemEvent,
     },
     rpc::{
         ChainBlock,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use sp_core::storage::{
     StorageChangeSet,
     StorageKey,
 };
-use sp_runtime::traits::SignedExtension;
+pub use sp_runtime::traits::SignedExtension;
 use sp_version::RuntimeVersion;
 use std::marker::PhantomData;
 

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -14,17 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
+use codec::Encode;
 use sp_runtime::{
     generic::Header,
     traits::{
         BlakeTwo256,
         IdentifyAccount,
+        SignedExtension,
         Verify,
     },
     MultiSignature,
     OpaqueExtrinsic,
 };
 
+use crate::extra::{DefaultExtra, SignedExtra};
 use crate::frame::{
     balances::{
         AccountData,
@@ -34,6 +37,14 @@ use crate::frame::{
     system::System,
 };
 
+/// Runtime trait.
+pub trait Runtime: System + Sized + Send + Sync + 'static {
+    /// Signature type.
+    type Signature: Encode + Send + Sync + 'static;
+    /// Transaction extras.
+    type Extra: SignedExtra<Self> + SignedExtension + Send;
+}
+
 /// Concrete type definitions compatible with those in the default substrate `node_runtime`
 ///
 /// # Note
@@ -42,6 +53,11 @@ use crate::frame::{
 /// definition MUST be used to ensure type compatibility.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DefaultNodeRuntime;
+
+impl Runtime for DefaultNodeRuntime {
+    type Signature = MultiSignature;
+    type Extra = DefaultExtra<Self>;
+}
 
 impl System for DefaultNodeRuntime {
     type Index = u32;
@@ -70,6 +86,11 @@ impl Contracts for DefaultNodeRuntime {}
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NodeTemplateRuntime;
 
+impl Runtime for NodeTemplateRuntime {
+    type Signature = MultiSignature;
+    type Extra = DefaultExtra<Self>;
+}
+
 impl System for NodeTemplateRuntime {
     type Index = u32;
     type BlockNumber = u32;
@@ -94,6 +115,11 @@ impl Balances for NodeTemplateRuntime {
 /// Also the contracts module is not part of the kusama runtime.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct KusamaRuntime;
+
+impl Runtime for KusamaRuntime {
+    type Signature = MultiSignature;
+    type Extra = DefaultExtra<Self>;
+}
 
 impl System for KusamaRuntime {
     type Index = u32;

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -20,30 +20,49 @@ use sp_runtime::{
     traits::{
         BlakeTwo256,
         IdentifyAccount,
-        SignedExtension,
         Verify,
     },
     MultiSignature,
     OpaqueExtrinsic,
 };
 
-use crate::extra::{DefaultExtra, SignedExtra};
-use crate::frame::{
-    balances::{
-        AccountData,
-        Balances,
+use crate::{
+    extra::{
+        DefaultExtra,
+        SignedExtra,
     },
-    contracts::Contracts,
-    system::System,
+    frame::{
+        balances::{
+            AccountData,
+            Balances,
+        },
+        contracts::Contracts,
+        system::System,
+    },
+    Encoded,
 };
 
 /// Runtime trait.
 pub trait Runtime: System + Sized + Send + Sync + 'static {
     /// Signature type.
-    type Signature: Encode + Send + Sync + 'static;
+    type Signature: Verify + Encode + Send + Sync + 'static;
     /// Transaction extras.
-    type Extra: SignedExtra<Self> + SignedExtension + Send;
+    type Extra: SignedExtra<Self> + Send + Sync + 'static;
 }
+
+/// Extra type.
+pub type Extra<T> = <<T as Runtime>::Extra as SignedExtra<T>>::Extra;
+
+/// UncheckedExtrinsic type.
+pub type UncheckedExtrinsic<T> = sp_runtime::generic::UncheckedExtrinsic<
+    <T as System>::Address,
+    Encoded,
+    <T as Runtime>::Signature,
+    Extra<T>,
+>;
+
+/// SignedPayload type.
+pub type SignedPayload<T> = sp_runtime::generic::SignedPayload<Encoded, Extra<T>>;
 
 /// Concrete type definitions compatible with those in the default substrate `node_runtime`
 ///

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -97,6 +97,8 @@ impl Balances for DefaultNodeRuntime {
 
 impl Contracts for DefaultNodeRuntime {}
 
+impl Sudo for DefaultNodeRuntime {}
+
 /// Concrete type definitions compatible with the node template.
 ///
 /// # Note

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -37,6 +37,7 @@ use crate::{
             Balances,
         },
         contracts::Contracts,
+        sudo::Sudo,
         system::System,
     },
     Encoded,
@@ -125,6 +126,8 @@ impl System for NodeTemplateRuntime {
 impl Balances for NodeTemplateRuntime {
     type Balance = u128;
 }
+
+impl Sudo for NodeTemplateRuntime {}
 
 /// Concrete type definitions compatible with those for kusama, v0.7
 ///


### PR DESCRIPTION
- Improves error messages in proc-macros (closes #122)
- Makes Signature and Extra associated types of a Runtime trait
- Removes special casing of system events
- If an extrinsic fails `watch` will return an error (closes #103)
- Adds support for decoding runtime error names from metadata
- Adds sudo to test for `BadOrigin` errors (closes #112)
- Adds a test to balances module to test for `InsufficientBalance` error