### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.11.0
+
+* Rc5 [#143](https://github.com/paritytech/substrate-subxt/pull/143)
+* Refactor: extract functions and types for creating extrinsics [#138](https://github.com/paritytech/substrate
+-subxt/pull/138)
+* event subscription example [#140](https://github.com/paritytech/substrate-subxt/pull/140)
+* Document the `Call` derive macro (#137)
+* Document the #[module] macro (#135)
+* Support authors api. (#134)
+
 # Version 0.10.1 (2020-06-19)
 
 * Release client v0.2.0 [#133](https://github.com/paritytech/substrate-subxt/pull/133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 0.11.0
 
+* Fix build error, wabt 0.9.2 is yanked [#146](https://github.com/paritytech/substrate-subxt/pull/146)
 * Rc5 [#143](https://github.com/paritytech/substrate-subxt/pull/143)
 * Refactor: extract functions and types for creating extrinsics [#138](https://github.com/paritytech/substrate-subxt/pull/138)
 * event subscription example [#140](https://github.com/paritytech/substrate-subxt/pull/140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 * Refactor: extract functions and types for creating extrinsics [#138](https://github.com/paritytech/substrate
 -subxt/pull/138)
 * event subscription example [#140](https://github.com/paritytech/substrate-subxt/pull/140)
-* Document the `Call` derive macro (#137)
-* Document the #[module] macro (#135)
-* Support authors api. (#134)
+* Document the `Call` derive macro [#137](https://github.com/paritytech/substrate-subxt/pull/137)
+* Document the #[module] macro [#135](https://github.com/paritytech/substrate-subxt/pull/135)
+* Support authors api. [#134](https://github.com/paritytech/substrate-subxt/pull/134)
 
 # Version 0.10.1 (2020-06-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Version 0.11.0
 
 * Rc5 [#143](https://github.com/paritytech/substrate-subxt/pull/143)
-* Refactor: extract functions and types for creating extrinsics [#138](https://github.com/paritytech/substrate
--subxt/pull/138)
+* Refactor: extract functions and types for creating extrinsics [#138](https://github.com/paritytech/substrate-subxt/pull/138)
 * event subscription example [#140](https://github.com/paritytech/substrate-subxt/pull/140)
 * Document the `Call` derive macro [#137](https://github.com/paritytech/substrate-subxt/pull/137)
 * Document the #[module] macro [#135](https://github.com/paritytech/substrate-subxt/pull/135)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,3 @@ substrate-subxt-client = { version = "0.3.0", path = "client" }
 tempdir = "0.3.7"
 test-node = { path = "test-node" }
 wabt = "0.10.0"
-wabt-sys = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num-traits = { version = "0.2.12", default-features = false }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 url = "2.1.1"
-codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive", "full"] }
 
 frame-metadata = { version = "11.0.0-rc5", package = "frame-metadata" }
 frame-support = { version = "2.0.0-rc5", package = "frame-support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "client", "proc-macro", "test-node"]
 
 [package]
 name = "substrate-subxt"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -40,8 +40,8 @@ sp-rpc = { version = "2.0.0-rc5", package = "sp-rpc" }
 sp-core = { version = "2.0.0-rc5", package = "sp-core" }
 sc-rpc-api = { version = "0.8.0-rc5", package = "sc-rpc-api" }
 sp-transaction-pool = { version = "2.0.0-rc5", package = "sp-transaction-pool" }
-substrate-subxt-client = { version = "0.2.0", path = "client", optional = true }
-substrate-subxt-proc-macro = { version = "0.9.0", path = "proc-macro" }
+substrate-subxt-client = { version = "0.3.0", path = "client", optional = true }
+substrate-subxt-proc-macro = { version = "0.11.0", path = "proc-macro" }
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
@@ -49,8 +49,7 @@ env_logger = "0.7.1"
 frame-system = { version = "2.0.0-rc5", package = "frame-system" }
 pallet-balances = { version = "2.0.0-rc5", package = "pallet-balances" }
 sp-keyring = { version = "2.0.0-rc5", package = "sp-keyring" }
-substrate-subxt-client = { version = "0.2.0", path = "client" }
+substrate-subxt-client = { version = "0.3.0", path = "client" }
 tempdir = "0.3.7"
 test-node = { path = "test-node" }
 wabt = "0.9.2"
-wabt-sys = "0.7.2"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-client"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-proc-macro"
-version = "0.9.0"
+version = "0.11.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 autotests = false

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -25,7 +25,7 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
-codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"] }
 env_logger = "0.7.1"
 pretty_assertions = "0.6.1"
 sp-keyring = "2.0.0-rc5"

--- a/test-node/runtime/Cargo.toml
+++ b/test-node/runtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 
 aura = { version = "2.0.0-rc5", default-features = false, package = "pallet-aura" }
 balances = { version = "2.0.0-rc5", default-features = false, package = "pallet-balances" }


### PR DESCRIPTION
* Rc5 [#143](https://github.com/paritytech/substrate-subxt/pull/143)
* Refactor: extract functions and types for creating extrinsics [#138](https://github.com/paritytech/substrate-subxt/pull/138)
* event subscription example [#140](https://github.com/paritytech/substrate-subxt/pull/140)
* Document the `Call` derive macro [#137](https://github.com/paritytech/substrate-subxt/pull/137)
* Document the #[module] macro [#135](https://github.com/paritytech/substrate-subxt/pull/135)
* Support authors api. [#134](https://github.com/paritytech/substrate-subxt/pull/134)