### PR TITLE
Fetch all from storage map

### DIFF
--- a/examples/fetch_all_accounts.rs
+++ b/examples/fetch_all_accounts.rs
@@ -16,8 +16,8 @@
 
 use sp_keyring::AccountKeyring;
 use substrate_subxt::{
-    system::*,
     system,
+    system::*,
     ClientBuilder,
     DefaultNodeRuntime,
     PairSigner,
@@ -28,7 +28,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let _client = ClientBuilder::<DefaultNodeRuntime>::new().build().await?;
-    // todo: impl accounts_iter in macro
     // for (key, account) in client.accounts_iter() {
     //     println!("{}: {}", key, account)
     // }

--- a/examples/fetch_all_accounts.rs
+++ b/examples/fetch_all_accounts.rs
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of substrate-subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+use sp_keyring::AccountKeyring;
+use substrate_subxt::{
+    system::*,
+    system,
+    ClientBuilder,
+    DefaultNodeRuntime,
+    PairSigner,
+};
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let _client = ClientBuilder::<DefaultNodeRuntime>::new().build().await?;
+    // todo: impl accounts_iter in macro
+    // for (key, account) in client.accounts_iter() {
+    //     println!("{}: {}", key, account)
+    // }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,9 @@ impl<T: Runtime> Client<T> {
         }
     }
 
-	/// Fetch up to `count` keys for a storage map in lexicographic order.
-	///
-	/// Supports pagination by passing a value to `start_key`.
+    /// Fetch up to `count` keys for a storage map in lexicographic order.
+    ///
+    /// Supports pagination by passing a value to `start_key`.
     pub async fn fetch_keys<F: Store<T>>(
         &self,
         count: u32,
@@ -238,7 +238,10 @@ impl<T: Runtime> Client<T> {
         hash: Option<T::Hash>,
     ) -> Result<Vec<StorageKey>, Error> {
         let prefix = <F as Store<T>>::prefix(&self.metadata)?;
-        let keys = self.rpc.storage_keys_paged(Some(prefix), count, start_key, hash).await?;
+        let keys = self
+            .rpc
+            .storage_keys_paged(Some(prefix), count, start_key, hash)
+            .await?;
         Ok(keys)
     }
 
@@ -630,7 +633,10 @@ mod tests {
     #[async_std::test]
     async fn test_fetch_keys() {
         let (client, _) = test_client().await;
-        let keys = client.fetch_keys::<system::AccountStore<_>>(4, None, None).await.unwrap();
+        let keys = client
+            .fetch_keys::<system::AccountStore<_>>(4, None, None)
+            .await
+            .unwrap();
         assert_eq!(keys.len(), 4)
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -132,8 +132,8 @@ impl<T: Runtime> Rpc<T> {
     }
 
     /// Returns the keys with prefix with pagination support.
-	/// Up to `count` keys will be returned.
-	/// If `start_key` is passed, return next keys in storage in lexicographic order.
+    /// Up to `count` keys will be returned.
+    /// If `start_key` is passed, return next keys in storage in lexicographic order.
     pub async fn storage_keys_paged(
         &self,
         prefix: Option<StorageKey>,


### PR DESCRIPTION
*WIP* Closes #144.

Mistakenly pushed the first part of this in https://github.com/paritytech/substrate-subxt/commit/663934ca374983308fa3cceccbbb58f59b6785b3.

## todo

- [ ] Create an `Iterator` to perform paging requests
- [ ] Add client config to override default page size
- [ ] Add method for creating the iterator in `proc_macro` e.g. `fn accounts_iter()`

