### PR TITLE
Only return an error if the extrinsic failed.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -39,7 +39,10 @@ use std::{
 };
 
 use crate::{
-    error::Error,
+    error::{
+        Error,
+        RuntimeError,
+    },
     metadata::{
         EventArg,
         Metadata,
@@ -168,7 +171,9 @@ impl<T: System> EventsDecoder<T> {
                         }
                     };
                     if let Err(error) = result {
-                        Error::from_dispatch(&self.metadata, error)?;
+                        return Err(
+                            RuntimeError::from_dispatch(&self.metadata, error)?.into()
+                        )
                     }
                 }
             }
@@ -177,10 +182,7 @@ impl<T: System> EventsDecoder<T> {
     }
 
     /// Decode events.
-    pub fn decode_events(
-        &self,
-        input: &mut &[u8],
-    ) -> Result<Vec<(Phase, RawEvent)>, Error> {
+    pub fn decode_events(&self, input: &mut &[u8]) -> Result<Vec<(Phase, Raw)>, Error> {
         let compact_len = <Compact<u32>>::decode(input)?;
         let len = compact_len.0 as usize;
 
@@ -201,20 +203,36 @@ impl<T: System> EventsDecoder<T> {
             );
 
             let mut event_data = Vec::<u8>::new();
-            self.decode_raw_bytes(&event_metadata.arguments(), input, &mut event_data)?;
+            let result = self.decode_raw_bytes(
+                &event_metadata.arguments(),
+                input,
+                &mut event_data,
+            );
+            let raw = match result {
+                Ok(()) => {
+                    log::debug!("raw bytes: {}", hex::encode(&event_data),);
 
-            log::debug!("raw bytes: {}", hex::encode(&event_data),);
+                    let event = RawEvent {
+                        module: module.name().to_string(),
+                        variant: event_metadata.name.clone(),
+                        data: event_data,
+                    };
 
-            let event = RawEvent {
-                module: module.name().to_string(),
-                variant: event_metadata.name.clone(),
-                data: event_data,
+                    // topics come after the event data in EventRecord
+                    let _topics = Vec::<T::Hash>::decode(input)?;
+                    Raw::Event(event)
+                }
+                Err(Error::Runtime(err)) => Raw::Error(err),
+                Err(err) => return Err(err),
             };
 
-            // topics come after the event data in EventRecord
-            let _topics = Vec::<T::Hash>::decode(input)?;
-            r.push((phase, event));
+            r.push((phase, raw));
         }
         Ok(r)
     }
+}
+
+pub enum Raw {
+    Event(RawEvent),
+    Error(RuntimeError),
 }

--- a/src/frame/balances.rs
+++ b/src/frame/balances.rs
@@ -112,6 +112,7 @@ mod tests {
     use crate::{
         error::{
             Error,
+            ModuleError,
             RuntimeError,
         },
         events::EventsDecoder,
@@ -193,8 +194,8 @@ mod tests {
         let res = client
             .transfer_and_watch(&hans, alice.account_id(), 100_000_000_000)
             .await;
-        if let Err(Error::Runtime(error)) = res {
-            let error2 = RuntimeError {
+        if let Err(Error::Runtime(RuntimeError::Module(error))) = res {
+            let error2 = ModuleError {
                 module: "Balances".into(),
                 error: "InsufficientBalance".into(),
             };

--- a/src/frame/sudo.rs
+++ b/src/frame/sudo.rs
@@ -43,7 +43,10 @@ pub struct SudoCall<'a, T: Sudo> {
 mod tests {
     use super::*;
     use crate::{
-        error::Error,
+        error::{
+            Error,
+            RuntimeError,
+        },
         extrinsic::PairSigner,
         frame::balances::TransferCall,
         tests::{
@@ -68,7 +71,7 @@ mod tests {
 
         let res = client.sudo_and_watch(&alice, &call).await;
         assert!(
-            if let Err(Error::BadOrigin) = res {
+            if let Err(Error::Runtime(RuntimeError::BadOrigin)) = res {
                 true
             } else {
                 false

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -22,6 +22,7 @@ use crate::{
     error::Error,
     events::{
         EventsDecoder,
+        Raw,
         RawEvent,
     },
     frame::{
@@ -99,13 +100,17 @@ impl<T: Runtime> EventSubscription<T> {
                         Ok(events) => events,
                         Err(error) => return Some(Err(error)),
                     };
-                    for (phase, event) in raw_events {
+                    for (phase, raw) in raw_events {
                         if let Phase::ApplyExtrinsic(i) = phase {
                             if let Some(ext_index) = self.extrinsic {
                                 if i as usize != ext_index {
                                     continue
                                 }
                             }
+                            let event = match raw {
+                                Raw::Event(event) => event,
+                                Raw::Error(err) => return Some(Err(err.into())),
+                            };
                             if let Some((module, variant)) = self.event {
                                 if event.module != module || event.variant != variant {
                                     continue


### PR DESCRIPTION
If an extrinsic in a block fails, all extrinsics will report a failure. We check the phase when watching an extrinsic and ignore errors of other extriniscs.