### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.12.0
+
+* Only return an error if the extrinsic failed. [#156](https://github.com/paritytech/substrate-subxt/pull/156)
+* Update to rc6. [#155](https://github.com/paritytech/substrate-subxt/pull/155)
+* Different assert. [#153](https://github.com/paritytech/substrate-subxt/pull/153)
+* Add a method to fetch an unhashed key, close #100 [#152](https://github.com/paritytech/substrate-subxt/pull/152)
+* Fix port number. [#151](https://github.com/paritytech/substrate-subxt/pull/151)
+* Implement the `concat` in `twox_64_concat` [#150](https://github.com/paritytech/substrate-subxt/pull/150)
+* Storage map iter [#148](https://github.com/paritytech/substrate-subxt/pull/148)
+
 # Version 0.11.0
 
 * Fix build error, wabt 0.9.2 is yanked [#146](https://github.com/paritytech/substrate-subxt/pull/146)
@@ -29,7 +39,7 @@
 # Version 0.8.0 (2020-05-26)
 
 * Update to Substrate release candidate [#116](https://github.com/paritytech/substrate-subxt/pull/116)
-* Update to alpha.8 [#114]c
+* Update to alpha.8 [#114](https://github.com/paritytech/substrate-subxt/pull/114)
 * Refactors the api [#113](https://github.com/paritytech/substrate-subxt/pull/113)
 
 # Version 0.7.0 (2020-05-13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ sp-rpc = { version = "2.0.0-rc6", package = "sp-rpc" }
 sp-core = { version = "2.0.0-rc6", package = "sp-core" }
 sc-rpc-api = { version = "0.8.0-rc6", package = "sc-rpc-api" }
 sp-transaction-pool = { version = "2.0.0-rc6", package = "sp-transaction-pool" }
-substrate-subxt-client = { version = "0.3.0", path = "client", optional = true }
+substrate-subxt-client = { version = "0.4.0", path = "client", optional = true }
 substrate-subxt-proc-macro = { version = "0.12.0", path = "proc-macro" }
 
 [dev-dependencies]
@@ -49,7 +49,7 @@ env_logger = "0.7.1"
 frame-system = { version = "2.0.0-rc6", package = "frame-system" }
 pallet-balances = { version = "2.0.0-rc6", package = "pallet-balances" }
 sp-keyring = { version = "2.0.0-rc6", package = "sp-keyring" }
-substrate-subxt-client = { version = "0.3.0", path = "client" }
+substrate-subxt-client = { version = "0.4.0", path = "client" }
 tempdir = "0.3.7"
 test-node = { path = "test-node" }
 wabt = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ sp-core = { version = "2.0.0-rc6", package = "sp-core" }
 sc-rpc-api = { version = "0.8.0-rc6", package = "sc-rpc-api" }
 sp-transaction-pool = { version = "2.0.0-rc6", package = "sp-transaction-pool" }
 substrate-subxt-client = { version = "0.3.0", path = "client", optional = true }
-substrate-subxt-proc-macro = { version = "0.11.0", path = "proc-macro" }
+substrate-subxt-proc-macro = { version = "0.12.0", path = "proc-macro" }
 
 [dev-dependencies]
 async-std = { version = "1.6.3", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "client", "proc-macro", "test-node"]
 
 [package]
 name = "substrate-subxt"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-client"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-proc-macro"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 autotests = false


### PR DESCRIPTION
* Only return an error if the extrinsic failed. [#156](https://github.com/paritytech/substrate-subxt/pull/156)
* Update to rc6. [#155](https://github.com/paritytech/substrate-subxt/pull/155)
* Different assert. [#153](https://github.com/paritytech/substrate-subxt/pull/153)
* Add a method to fetch an unhashed key, close #100 [#152](https://github.com/paritytech/substrate-subxt/pull/152)
* Fix port number. [#151](https://github.com/paritytech/substrate-subxt/pull/151)
* Implement the `concat` in `twox_64_concat` [#150](https://github.com/paritytech/substrate-subxt/pull/150)
* Storage map iter [#148](https://github.com/paritytech/substrate-subxt/pull/148)