### PR TITLE
decode option event arg

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -154,6 +154,17 @@ impl<T: System> EventsDecoder<T> {
                         self.decode_raw_bytes(&[*arg.clone()], input, output)?
                     }
                 }
+                EventArg::Option(arg) => {
+                    match input.read_byte()? {
+                        0 => (),
+                        1 => self.decode_raw_bytes(&[*arg.clone()], input, output)?,
+                        _ => {
+                            return Err(Error::Other(
+                                "unexpected first byte decoding Option".into(),
+                            ))
+                        }
+                    }
+                }
                 EventArg::Tuple(args) => self.decode_raw_bytes(args, input, output)?,
                 EventArg::Primitive(name) => {
                     let result = match name.as_str() {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -398,6 +398,7 @@ pub enum EventArg {
     Primitive(String),
     Vec(Box<EventArg>),
     Tuple(Vec<EventArg>),
+    Option(Box<EventArg>),
 }
 
 impl FromStr for EventArg {
@@ -411,6 +412,15 @@ impl FromStr for EventArg {
                 Err(ConversionError::InvalidEventArg(
                     s.to_string(),
                     "Expected closing `>` for `Vec`",
+                ))
+            }
+        } else if s.starts_with("Option<") {
+            if s.ends_with('>') {
+                Ok(EventArg::Option(Box::new(s[7..s.len() - 1].parse()?)))
+            } else {
+                Err(ConversionError::InvalidEventArg(
+                    s.to_string(),
+                    "Expected closing `>` for `Option`",
                 ))
             }
         } else if s.starts_with('(') {
@@ -439,6 +449,7 @@ impl EventArg {
         match self {
             EventArg::Primitive(p) => vec![p.clone()],
             EventArg::Vec(arg) => arg.primitives(),
+            EventArg::Option(arg) => arg.primitives(),
             EventArg::Tuple(args) => {
                 let mut primitives = Vec::new();
                 for arg in args {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

A lot of code shift here is due to `cargo fmt`, I can revert this if needs be. The main change here is to enable `Option` decoding, required for [PolkaBTC](https://github.com/interlay/BTC-Parachain/blob/master/crates/staked-relayers/src/lib.rs#L1039).

EDIT: `cargo +nightly fmt` fixed it, thanks @dvc94ch 