### PR TITLE
fix option decoding and add basic sanity test

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -73,7 +73,7 @@ pub enum MetadataError {
 }
 
 /// Runtime metadata.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Metadata {
     modules: HashMap<String, ModuleMetadata>,
     modules_with_calls: HashMap<String, ModuleWithCalls>,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

The previous fix was not complete, we need to update the output bytes to indicate whether the `Option` is `Some` or `None`. I've also added a small test to validate this against the codec library.