### PR TITLE
Remove visibility limiter `pub (crate)` from Metadata

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -93,10 +93,7 @@ impl Metadata {
             .ok_or(MetadataError::ModuleNotFound(name))
     }
 
-    pub fn module_with_calls<S>(
-        &self,
-        name: S,
-    ) -> Result<&ModuleWithCalls, MetadataError>
+    pub fn module_with_calls<S>(&self, name: S) -> Result<&ModuleWithCalls, MetadataError>
     where
         S: ToString,
     {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -93,7 +93,7 @@ impl Metadata {
             .ok_or(MetadataError::ModuleNotFound(name))
     }
 
-    pub(crate) fn module_with_calls<S>(
+    pub fn module_with_calls<S>(
         &self,
         name: S,
     ) -> Result<&ModuleWithCalls, MetadataError>
@@ -106,11 +106,11 @@ impl Metadata {
             .ok_or(MetadataError::ModuleNotFound(name))
     }
 
-    pub(crate) fn modules_with_events(&self) -> impl Iterator<Item = &ModuleWithEvents> {
+    pub fn modules_with_events(&self) -> impl Iterator<Item = &ModuleWithEvents> {
         self.modules_with_events.values()
     }
 
-    pub(crate) fn module_with_events(
+    pub fn module_with_events(
         &self,
         module_index: u8,
     ) -> Result<&ModuleWithEvents, MetadataError> {
@@ -120,7 +120,7 @@ impl Metadata {
             .ok_or(MetadataError::ModuleIndexNotFound(module_index))
     }
 
-    pub(crate) fn module_with_errors(
+    pub fn module_with_errors(
         &self,
         module_index: u8,
     ) -> Result<&ModuleWithErrors, MetadataError> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -93,6 +93,7 @@ impl Metadata {
             .ok_or(MetadataError::ModuleNotFound(name))
     }
 
+    /// Returns `ModuleWithCalls`.
     pub fn module_with_calls<S>(&self, name: S) -> Result<&ModuleWithCalls, MetadataError>
     where
         S: ToString,
@@ -103,10 +104,12 @@ impl Metadata {
             .ok_or(MetadataError::ModuleNotFound(name))
     }
 
+    /// Returns Iterator of `ModuleWithEvents`.
     pub fn modules_with_events(&self) -> impl Iterator<Item = &ModuleWithEvents> {
         self.modules_with_events.values()
     }
 
+    /// Returns `ModuleWithEvents`.
     pub fn module_with_events(
         &self,
         module_index: u8,
@@ -117,6 +120,7 @@ impl Metadata {
             .ok_or(MetadataError::ModuleIndexNotFound(module_index))
     }
 
+    /// Returns `ModuleWithErrors`.
     pub fn module_with_errors(
         &self,
         module_index: u8,


### PR DESCRIPTION
I faced that I could not use Metadata's main functions outside of the crate and don't see any reason why these functions should be invisible to outside.