### PR TITLE
Fix up contracts pallet tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [features]
 client = ["substrate-subxt-client"]
 
+# enable this feature to run tests which require a local dev chain node
+integration-tests = []
+
 [dependencies]
 log = "0.4.11"
 thiserror = "1.0.20"

--- a/src/frame/contracts.rs
+++ b/src/frame/contracts.rs
@@ -120,7 +120,11 @@ mod tests {
     use sp_keyring::AccountKeyring;
 
     use super::*;
-    use crate::{ClientBuilder, PairSigner, ContractsTemplateRuntime};
+    use crate::{
+        ClientBuilder,
+        ContractsTemplateRuntime,
+        PairSigner,
+    };
 
     fn contract_wasm() -> Vec<u8> {
         const CONTRACT: &str = r#"
@@ -138,7 +142,10 @@ mod tests {
         env_logger::try_init().ok();
 
         let signer = PairSigner::new(AccountKeyring::Alice.pair());
-        let client = ClientBuilder::<ContractsTemplateRuntime>::new().build().await.unwrap();
+        let client = ClientBuilder::<ContractsTemplateRuntime>::new()
+            .build()
+            .await
+            .unwrap();
 
         let code = contract_wasm();
         let result = client.put_code_and_watch(&signer, &code).await.unwrap();
@@ -158,7 +165,10 @@ mod tests {
     async fn tx_instantiate() {
         env_logger::try_init().ok();
         let signer = PairSigner::new(AccountKeyring::Bob.pair());
-        let client = ClientBuilder::<ContractsTemplateRuntime>::new().build().await.unwrap();
+        let client = ClientBuilder::<ContractsTemplateRuntime>::new()
+            .build()
+            .await
+            .unwrap();
 
         // call put_code extrinsic
         let code = contract_wasm();
@@ -172,10 +182,10 @@ mod tests {
         let result = client
             .instantiate_and_watch(
                 &signer,
-                100_000_000_000_000,    // endowment
-                500_000_000,            // gas_limit
+                100_000_000_000_000, // endowment
+                500_000_000,         // gas_limit
                 &code_hash,
-                &[],                    // data
+                &[], // data
             )
             .await
             .unwrap();

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -116,6 +116,39 @@ impl Balances for NodeTemplateRuntime {
 
 impl Sudo for NodeTemplateRuntime {}
 
+/// Concrete type definitions compatible with the node template, with the
+/// contracts pallet enabled.
+///
+/// Inherits types from [`NodeTemplateRuntime`], but adds an implementation for
+/// the contracts pallet trait.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ContractsTemplateRuntime;
+
+impl Runtime for ContractsTemplateRuntime {
+    type Signature = <NodeTemplateRuntime as Runtime>::Signature;
+    type Extra = DefaultExtra<Self>;
+}
+
+impl System for ContractsTemplateRuntime {
+    type Index = <NodeTemplateRuntime as System>::Index;
+    type BlockNumber = <NodeTemplateRuntime as System>::BlockNumber;
+    type Hash = <NodeTemplateRuntime as System>::Hash;
+    type Hashing = <NodeTemplateRuntime as System>::Hashing;
+    type AccountId = <NodeTemplateRuntime as System>::AccountId;
+    type Address = <NodeTemplateRuntime as System>::Address;
+    type Header = <NodeTemplateRuntime as System>::Header;
+    type Extrinsic = <NodeTemplateRuntime as System>::Extrinsic;
+    type AccountData = <NodeTemplateRuntime as System>::AccountData;
+}
+
+impl Balances for ContractsTemplateRuntime {
+    type Balance = <NodeTemplateRuntime as Balances>::Balance;
+}
+
+impl Contracts for ContractsTemplateRuntime {}
+
+impl Sudo for ContractsTemplateRuntime {}
+
 /// Concrete type definitions compatible with those for kusama, v0.7
 ///
 /// # Note


### PR DESCRIPTION
- Revert contracts put_code test to pure code (not using the `subxt_test` macro), for better readability and debuggability (is that a word?)
- Add runtime for the node template with the contracts module added. 
- Add `integration-tests` feature for tests which require a running substrate node, instead of just `#[ignore]`ing them