### PR TITLE
allow downstream users to consume custom rpc endpoints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,14 @@ pub use sp_runtime;
 
 use codec::Decode;
 use futures::future;
-use jsonrpsee::client::Subscription;
+pub use jsonrpsee::common::{
+    to_value as to_json_value,
+    Params,
+};
+use jsonrpsee::{
+    client::Subscription,
+    common::DeserializeOwned,
+};
 use sc_rpc_api::state::ReadProof;
 use sp_core::{
     storage::{
@@ -544,6 +551,15 @@ impl<T: Runtime> Client<T> {
         key_type: String,
     ) -> Result<bool, Error> {
         self.rpc.has_key(public_key, key_type).await
+    }
+
+    /// Send a custom RPC message
+    pub async fn send_msg<R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: Params,
+    ) -> Result<R, Error> {
+        self.rpc.send_msg(method, params).await
     }
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -33,6 +33,7 @@ use jsonrpsee::{
     client::Subscription,
     common::{
         to_value as to_json_value,
+        DeserializeOwned,
         Params,
     },
     Client,
@@ -476,6 +477,14 @@ impl<T: Runtime> Rpc<T> {
         let params =
             Params::Array(vec![to_json_value(public_key)?, to_json_value(key_type)?]);
         Ok(self.client.request("author_hasKey", params).await?)
+    }
+
+    pub async fn send_msg<R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: Params,
+    ) -> Result<R, Error> {
+        Ok(self.client.request(method, params).await?)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Allow client to call custom runtime APIs by invoking `send_msg` with method name and parameters.