### PR TITLE
Remove unnecessary Sync requirements

### DIFF
--- a/src/extrinsic/signer.rs
+++ b/src/extrinsic/signer.rs
@@ -50,7 +50,7 @@ pub trait Signer<T: Runtime> {
     fn sign(
         &self,
         extrinsic: SignedPayload<T>,
-    ) -> Pin<Box<dyn Future<Output = Result<UncheckedExtrinsic<T>, String>> + Send + Sync>>;
+    ) -> Pin<Box<dyn Future<Output = Result<UncheckedExtrinsic<T>, String>> + Send>>;
 }
 
 /// Extrinsic signer using a private key.
@@ -100,8 +100,7 @@ impl<T, P> Signer<T> for PairSigner<T, P>
 where
     T: Runtime,
     T::AccountId: Into<T::Address> + 'static,
-    <<T::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned:
-        Send + Sync,
+    <<T::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send,
     P: Pair + 'static,
     P::Signature: Into<T::Signature> + 'static,
 {
@@ -116,8 +115,7 @@ where
     fn sign(
         &self,
         extrinsic: SignedPayload<T>,
-    ) -> Pin<Box<dyn Future<Output = Result<UncheckedExtrinsic<T>, String>> + Send + Sync>>
-    {
+    ) -> Pin<Box<dyn Future<Output = Result<UncheckedExtrinsic<T>, String>> + Send>> {
         let signature = extrinsic.using_encoded(|payload| self.signer.sign(payload));
         let (call, extra, _) = extrinsic.deconstruct();
         let extrinsic = UncheckedExtrinsic::<T>::new_signed(


### PR DESCRIPTION
This is needed for Ledgeracio, as Ledgeracio’s signer is now no longer `Send`.