### PR TITLE
Remove some substrate dependencies to improve compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,6 @@ pallet-staking = "2.0.0"
 
 sp-rpc = { version = "2.0.0", package = "sp-rpc" }
 sp-core = { version = "2.0.0", package = "sp-core" }
-sc-rpc-api = { version = "0.8.0", package = "sc-rpc-api" }
-sp-transaction-pool = { version = "2.0.0", package = "sp-transaction-pool" }
 substrate-subxt-client = { version = "0.5.0", path = "client", optional = true }
 substrate-subxt-proc-macro = { version = "0.13.0", path = "proc-macro" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,6 @@ pallet-indices = { version = "2.0.0", package = "pallet-indices" }
 hex = "0.4.2"
 sp-std = "2.0.0"
 application-crypto = { version = "2.0.0", package = "sp-application-crypto" }
-sp-finality-grandpa = "2.0.0"
-sp-consensus-babe = "0.8.0"
-pallet-im-online = "2.0.0"
-sp-authority-discovery = "2.0.0"
 pallet-staking = "2.0.0"
 
 sp-rpc = { version = "2.0.0", package = "sp-rpc" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ pub use sp_runtime;
 use codec::Decode;
 use futures::future;
 use jsonrpsee::client::Subscription;
-use sc_rpc_api::state::ReadProof;
 use sp_core::{
     storage::{
         StorageChangeSet,
@@ -94,6 +93,7 @@ pub use crate::{
     rpc::{
         BlockNumber,
         ExtrinsicSuccess,
+        ReadProof,
         SystemProperties,
     },
     runtimes::*,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -47,7 +47,7 @@ use sp_core::{
     twox_128,
     Bytes,
 };
-use csp_rpc::{
+use sp_rpc::{
     list::ListOrValue,
     number::NumberOrHex,
 };

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -37,7 +37,10 @@ use jsonrpsee::{
     },
     Client,
 };
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 use sp_core::{
     storage::{
         StorageChangeSet,

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -15,7 +15,6 @@
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
 use codec::Encode;
-use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sp_runtime::{
     generic::Header,
     impl_opaque_keys,
@@ -32,32 +31,54 @@ use sp_std::prelude::*;
 /// BABE marker struct
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Babe;
+
+/// Application specific crypto types
+pub mod app {
+    use application_crypto::{app_crypto, key_types, ed25519, sr25519};
+
+    /// Authority discovery app crypto types
+    pub mod authority_discovery {
+        use super::*;
+        app_crypto!(sr25519, key_types::AUTHORITY_DISCOVERY);
+    }
+    /// Babe app crypto types
+    pub mod babe {
+        use super::*;
+        app_crypto!(sr25519, key_types::BABE);
+    }
+    /// Im online discovery app crypto types
+    pub mod im_online {
+        use super::*;
+        app_crypto!(ed25519, key_types::IM_ONLINE);
+    }
+    /// Grandpa app crypto types
+    pub mod grandpa {
+        use super::*;
+        app_crypto!(ed25519, key_types::GRANDPA);
+    }
+    /// Validator app crypto types
+    pub mod validator {
+        use super::*;
+        app_crypto!(ed25519, sp_core::crypto::KeyTypeId(*b"para"));
+    }
+}
+
 impl sp_runtime::BoundToRuntimeAppPublic for Babe {
-    type Public = sp_consensus_babe::AuthorityId;
+    type Public = app::babe::Public;
 }
 
 /// ImOnline marker struct
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ImOnline;
 impl sp_runtime::BoundToRuntimeAppPublic for ImOnline {
-    type Public = ImOnlineId;
+    type Public = app::im_online::Public;
 }
 
 /// GRANDPA marker struct
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Grandpa;
 impl sp_runtime::BoundToRuntimeAppPublic for Grandpa {
-    type Public = sp_finality_grandpa::AuthorityId;
-}
-
-use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
-
-mod validator_app {
-    use application_crypto::{
-        app_crypto,
-        sr25519,
-    };
-    app_crypto!(sr25519, sp_core::crypto::KeyTypeId(*b"para"));
+    type Public = app::grandpa::Public;
 }
 
 /// Parachain marker struct
@@ -65,14 +86,14 @@ mod validator_app {
 pub struct Parachains;
 
 impl sp_runtime::BoundToRuntimeAppPublic for Parachains {
-    type Public = validator_app::Public;
+    type Public = app::validator::Public;
 }
 
 /// Authority discovery marker struct
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct AuthorityDiscovery;
 impl sp_runtime::BoundToRuntimeAppPublic for AuthorityDiscovery {
-    type Public = AuthorityDiscoveryId;
+    type Public = app::authority_discovery::Public;
 }
 
 impl_opaque_keys! {

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -34,7 +34,12 @@ pub struct Babe;
 
 /// Application specific crypto types
 pub mod app {
-    use application_crypto::{app_crypto, key_types, ed25519, sr25519};
+    use application_crypto::{
+        app_crypto,
+        ed25519,
+        key_types,
+        sr25519,
+    };
 
     /// Authority discovery app crypto types
     pub mod authority_discovery {

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -33,6 +33,11 @@ use sp_std::prelude::*;
 pub struct Babe;
 
 /// Application specific crypto types
+///
+/// # Note
+///
+/// These are redefined here to avoid dependencies on the substrate creates where they are defined.
+/// They must be identical to the definitions in the target substrate version.
 pub mod app {
     use application_crypto::{
         app_crypto,


### PR DESCRIPTION
Removes some big substrate dependencies which were only being used for one or two types. I have just copied these over verbatim, which is acceptable since we are targeting a specific version of substrate at the moment.

This shaves about a minute off the compile time, down from 3:42 to 2:46 on my machine.