### PR TITLE
Make RawEvent Cloneable && Add a wrapper rpc call && export request for custom rpc call.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -52,6 +52,7 @@ use crate::{
 };
 
 /// Raw bytes for an Event
+#[derive(Clone)]
 pub struct RawEvent {
     /// The name of the module from whence the Event originated
     pub module: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ extern crate substrate_subxt_proc_macro;
 #[cfg(feature = "client")]
 pub use substrate_subxt_client as client;
 
+pub use jsonrpsee::common::Params;
 pub use sp_core;
 pub use sp_runtime;
 
@@ -259,21 +260,20 @@ impl<T: Runtime> Client<T> {
         &self.genesis_hash
     }
 
-    /// Return rpc.
-    pub fn rpc(&self) -> &Rpc<T> {
-        &self.rpc
-    }
-
     /// Request method wrapper.
     pub async fn request<Ret>(
         &self,
         method: impl Into<String>,
-        params: impl Into<jsonrpsee::common::Params>,
-    ) -> Result<Ret, jsonrpsee::client::RequestError>
+        params: impl Into<Params>,
+    ) -> Result<Ret, Error>
     where
         Ret: jsonrpsee::common::DeserializeOwned,
     {
-        self.rpc().client().request(method, params).await
+        self.rpc
+            .client()
+            .request(method, params)
+            .await
+            .map_err(Into::into)
     }
 
     /// Returns the chain metadata.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,23 @@ impl<T: Runtime> Client<T> {
         &self.genesis_hash
     }
 
+    /// Return rpc.
+    pub fn rpc(&self) -> &Rpc<T> {
+        &self.rpc
+    }
+
+    /// Request method wrapper.
+    pub async fn request<Ret>(
+        &self,
+        method: impl Into<String>,
+        params: impl Into<jsonrpsee::common::Params>,
+    ) -> Result<Ret, jsonrpsee::client::RequestError>
+    where
+        Ret: jsonrpsee::common::DeserializeOwned,
+    {
+        self.rpc().client().request(method, params).await
+    }
+
     /// Returns the chain metadata.
     pub fn metadata(&self) -> &Metadata {
         &self.metadata

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,12 @@ impl<T: Runtime> Client<T> {
         Ok(head)
     }
 
+    /// Get a block hash of the latest block
+    pub async fn head(&self) -> Result<T::Hash, Error> {
+        let head = self.rpc.head().await?;
+        Ok(head)
+    }
+
     /// Get a block
     pub async fn block<H>(&self, hash: Option<H>) -> Result<Option<ChainBlock<T>>, Error>
     where

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -131,6 +131,11 @@ impl<T: Runtime> Rpc<T> {
         }
     }
 
+    /// return client
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
     /// Fetch a storage key
     pub async fn storage(
         &self,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -268,10 +268,7 @@ impl<T: Runtime> Rpc<T> {
 
     /// Get a block hash of the latest block
     pub async fn head(&self) -> Result<T::Hash, Error> {
-        let hash = self
-            .client
-            .request("chain_getHead", Params::None)
-            .await?;
+        let hash = self.client.request("chain_getHead", Params::None).await?;
         Ok(hash)
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -266,6 +266,15 @@ impl<T: Runtime> Rpc<T> {
         Ok(hash)
     }
 
+    /// Get a block hash of the latest block
+    pub async fn head(&self) -> Result<T::Hash, Error> {
+        let hash = self
+            .client
+            .request("chain_getHead", Params::None)
+            .await?;
+        Ok(hash)
+    }
+
     /// Get a Block
     pub async fn block(
         &self,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -131,8 +131,7 @@ impl<T: Runtime> Rpc<T> {
         }
     }
 
-    /// return client
-    pub fn client(&self) -> &Client {
+    pub(crate) fn client(&self) -> &Client {
         &self.client
     }
 


### PR DESCRIPTION
* RawEvent needs to implement Clone for multithread usage.
* Export request method, for non-standard rpc.
* Wrapped `chain_getHead` rpc call.