### PR TITLE
Fix 'Option' return of storage

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -261,7 +261,7 @@ impl ModuleWithErrors {
 pub struct StorageMetadata {
     module_prefix: String,
     storage_prefix: String,
-    modifier: StorageEntryModifier,
+    pub modifier: StorageEntryModifier,
     ty: StorageEntryType,
     default: Vec<u8>,
 }


### PR DESCRIPTION
Suppose a substrate storage's return type is `Option<Vec<_>>`. So its metadata modifier is `Optional` and value type is `Vec<_>`.

If the storage returns `Some([])`, the hex data is not `0x0100` but `0x00`, which will be decoded to `None`. This is wrong.
