### PR TITLE
Export extra types

### DIFF
--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -21,6 +21,13 @@ mod signer;
 
 pub use self::{
     extra::{
+        ChargeTransactionPayment,
+        CheckEra,
+        CheckGenesis,
+        CheckNonce,
+        CheckSpecVersion,
+        CheckTxVersion,
+        CheckWeight,
         DefaultExtra,
         Extra,
         SignedExtra,


### PR DESCRIPTION
`Extra` types are configurable within the runtime and not every single blockchain uses the default parameters. By re-exporting these types, users will only have to reference them instead of duplicating code implementation.