### PR TITLE
Refactor event type decoding and declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ frame-metadata = "12.0.1"
 frame-support = "2.0.1"
 sp-runtime = "2.0.1"
 sp-version = "2.0.1"
+sp-finality-grandpa = { version = "2.0.1", default-features = false }
 pallet-indices = "2.0.1"
 hex = "0.4.2"
 sp-std = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ frame-metadata = "12.0.1"
 frame-support = "2.0.1"
 sp-runtime = "2.0.1"
 sp-version = "2.0.1"
-sp-finality-grandpa = { version = "2.0.1", default-features = false }
 pallet-indices = "2.0.1"
 hex = "0.4.2"
 sp-std = "2.0.1"

--- a/proc-macro/src/module.rs
+++ b/proc-macro/src/module.rs
@@ -69,15 +69,60 @@ fn events_decoder_trait_name(module: &syn::Ident) -> syn::Ident {
 fn with_module_ident(module: &syn::Ident) -> syn::Ident {
     format_ident!("with_{}", module.to_string().to_snake_case())
 }
+
+type EventAttr = utils::UniAttr<syn::Type>;
+type EventAliasAttr = utils::UniAttr<utils::Attr<syn::Ident, syn::Type>>;
+
+/// Parses the event type definition macros within #[module]
+///
+/// It supports two ways to define the associated event type:
+///
+/// ```
+/// #[module]
+/// trait Pallet: System {
+///     #![event_type(SomeType)]
+///     #![event_alias(TypeNameAlias = SomeType)]
+///     #![event_alias(SomeOtherAlias = TypeWithAssociatedTypes<T>)]
+/// }
+/// ```
+fn parse_event_type_attr(attr: &syn::Attribute) -> Option<(String, syn::Type)> {
+    let ident = utils::path_to_ident(&attr.path);
+    if ident == "event_type" {
+        let attrs: EventAttr = syn::parse2(attr.tokens.clone())
+            .map_err(|err| abort!("{}", err))
+            .unwrap();
+        let ty = attrs.attr;
+        let ident_str = quote!(#ty).to_string();
+        Some((ident_str, ty))
+    } else if ident == "event_alias" {
+        let attrs: EventAliasAttr = syn::parse2(attr.tokens.clone())
+            .map_err(|err| abort!("{}", err))
+            .unwrap();
+        let ty = attrs.attr.value;
+        let ident_str = attrs.attr.key.to_string();
+        Some((ident_str, ty))
+    } else {
+        None
+    }
+}
+
 /// Attribute macro that registers the type sizes used by the module; also sets the `MODULE` constant.
 pub fn module(_args: TokenStream, tokens: TokenStream) -> TokenStream {
     let input: Result<syn::ItemTrait, _> = syn::parse2(tokens.clone());
-    let input = if let Ok(input) = input {
+    let mut input = if let Ok(input) = input {
         input
     } else {
         // handle #[module(ignore)] by just returning the tokens
         return tokens
     };
+
+    // Parse the inner attributes `event_type` and `event_alias` and remove them from the macro
+    // outputs.
+    let (other_attrs, event_types): (Vec<_>, Vec<_>) = input.attrs
+        .iter()
+        .cloned()
+        .partition(|attr| parse_event_type_attr(attr).is_none());
+    input.attrs = other_attrs;
 
     let subxt = utils::use_crate("substrate-subxt");
     let module = &input.ident;
@@ -96,7 +141,7 @@ pub fn module(_args: TokenStream, tokens: TokenStream) -> TokenStream {
             None
         }
     });
-    let types = input.items.iter().filter_map(|item| {
+    let associated_types = input.items.iter().filter_map(|item| {
         if let syn::TraitItem::Type(ty) = item {
             if ignore(&ty.attrs) {
                 return None
@@ -108,6 +153,12 @@ pub fn module(_args: TokenStream, tokens: TokenStream) -> TokenStream {
             })
         } else {
             None
+        }
+    });
+    let types = event_types.iter().map(|attr| {
+        let (ident_str, ty) = parse_event_type_attr(&attr).unwrap();
+        quote! {
+            self.register_type_size::<#ty>(#ident_str);
         }
     });
 
@@ -127,6 +178,7 @@ pub fn module(_args: TokenStream, tokens: TokenStream) -> TokenStream {
         {
             fn #with_module(&mut self) {
                 #(#bounds)*
+                #(#associated_types)*
                 #(#types)*
             }
         }

--- a/proc-macro/src/module.rs
+++ b/proc-macro/src/module.rs
@@ -77,7 +77,7 @@ type EventAliasAttr = utils::UniAttr<utils::Attr<syn::Ident, syn::Type>>;
 ///
 /// It supports two ways to define the associated event type:
 ///
-/// ```
+/// ```ignore
 /// #[module]
 /// trait Pallet: System {
 ///     #![event_type(SomeType)]

--- a/proc-macro/src/module.rs
+++ b/proc-macro/src/module.rs
@@ -118,7 +118,8 @@ pub fn module(_args: TokenStream, tokens: TokenStream) -> TokenStream {
 
     // Parse the inner attributes `event_type` and `event_alias` and remove them from the macro
     // outputs.
-    let (other_attrs, event_types): (Vec<_>, Vec<_>) = input.attrs
+    let (other_attrs, event_types): (Vec<_>, Vec<_>) = input
+        .attrs
         .iter()
         .cloned()
         .partition(|attr| parse_event_type_attr(attr).is_none());

--- a/proc-macro/src/utils.rs
+++ b/proc-macro/src/utils.rs
@@ -214,6 +214,21 @@ impl<K: Parse, V: Parse> Parse for Attr<K, V> {
     }
 }
 
+#[derive(Debug)]
+pub struct UniAttr<A> {
+    pub paren: syn::token::Paren,
+    pub attr: A,
+}
+
+impl<A: Parse> Parse for UniAttr<A> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        let paren = syn::parenthesized!(content in input);
+        let attr = content.parse()?;
+        Ok(Self { paren, attr })
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn assert_proc_macro(
     result: proc_macro2::TokenStream,

--- a/src/events.rs
+++ b/src/events.rs
@@ -72,14 +72,18 @@ impl std::fmt::Debug for RawEvent {
     }
 }
 
+/// Functions that take an input stream, consume an object, and output the serialized bytes.
+trait TypeSegmenterFn: Fn(&mut &[u8], &mut Vec<u8>) -> Result<(), Error> + Send {}
+impl<T> TypeSegmenterFn for T where
+    T: Fn(&mut &[u8], &mut Vec<u8>) -> Result<(), Error> + Send
+{
+}
+
 /// Events decoder.
 pub struct EventsDecoder<T> {
     metadata: Metadata,
     type_sizes: HashMap<String, usize>,
-    type_segmenters: HashMap<
-        String,
-        Box<dyn Fn(&mut &[u8], &mut Vec<u8>) -> Result<(), Error> + Send>,
-    >,
+    type_segmenters: HashMap<String, Box<dyn TypeSegmenterFn>>,
     marker: PhantomData<fn() -> T>,
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -28,11 +28,11 @@ use sp_runtime::{
     DispatchResult,
 };
 use std::{
-    fmt,
     collections::{
         HashMap,
         HashSet,
     },
+    fmt,
     marker::{
         PhantomData,
         Send,
@@ -78,7 +78,7 @@ pub struct EventsDecoder<T> {
     type_sizes: HashMap<String, usize>,
     type_segmenters: HashMap<
         String,
-        Box<dyn Fn(&mut &[u8], &mut Vec<u8>) -> Result<(), Error> + Send>
+        Box<dyn Fn(&mut &[u8], &mut Vec<u8>) -> Result<(), Error> + Send>,
     >,
     marker: PhantomData<fn() -> T>,
 }
@@ -137,11 +137,15 @@ impl<T: System> EventsDecoder<T> {
         self.type_sizes.insert(name.to_string(), size);
         // A segmenter decodes a type from an input stream (&mut &[u8]) and returns the serialized
         // type to the output stream (&mut Vec<u8>).
-        self.type_segmenters.insert(name.to_string(),
-            Box::new(|input: &mut &[u8], output: &mut Vec<u8>| -> Result<(), Error>  {
-                U::decode(input).map_err(Error::from)?.encode_to(output);
-                Ok(())
-            }));
+        self.type_segmenters.insert(
+            name.to_string(),
+            Box::new(
+                |input: &mut &[u8], output: &mut Vec<u8>| -> Result<(), Error> {
+                    U::decode(input).map_err(Error::from)?.encode_to(output);
+                    Ok(())
+                },
+            ),
+        );
         size
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -77,7 +77,9 @@ trait TypeSegmenter: Send {
     fn segment(&self, input: &mut &[u8], output: &mut Vec<u8>) -> Result<(), Error>;
 }
 
-impl<T> TypeSegmenter for PhantomData<T>
+#[derive(Default)]
+struct TypeMarker<T>(PhantomData<T>);
+impl<T> TypeSegmenter for TypeMarker<T>
 where
     T: Codec + Send,
 {
@@ -150,7 +152,7 @@ impl<T: System> EventsDecoder<T> {
         // A segmenter decodes a type from an input stream (&mut &[u8]) and returns the serialized
         // type to the output stream (&mut Vec<u8>).
         self.type_segmenters
-            .insert(name.to_string(), Box::new(PhantomData::<U>));
+            .insert(name.to_string(), Box::new(TypeMarker::<U>::default()));
         size
     }
 

--- a/src/frame/session.rs
+++ b/src/frame/session.rs
@@ -16,14 +16,14 @@
 
 //! Session support
 use crate::frame::{
+    balances::{
+        Balances,
+        BalancesEventsDecoder as _,
+    },
     system::{
         System,
         SystemEventsDecoder as _,
     },
-    balances::{
-        Balances,
-        BalancesEventsDecoder as _,
-    }
 };
 use codec::Encode;
 use frame_support::Parameter;
@@ -53,7 +53,7 @@ macro_rules! default_impl {
 
 type IdentificationTuple<T> = (
     <T as Session>::ValidatorId,
-    pallet_staking::Exposure<<T as System>::AccountId, <T as Balances>::Balance>
+    pallet_staking::Exposure<<T as System>::AccountId, <T as Balances>::Balance>,
 );
 
 /// The trait needed for this module.

--- a/src/frame/session.rs
+++ b/src/frame/session.rs
@@ -15,9 +15,15 @@
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Session support
-use crate::frame::system::{
-    System,
-    SystemEventsDecoder as _,
+use crate::frame::{
+    system::{
+        System,
+        SystemEventsDecoder as _,
+    },
+    balances::{
+        Balances,
+        BalancesEventsDecoder as _,
+    }
 };
 use codec::Encode;
 use frame_support::Parameter;
@@ -45,9 +51,18 @@ macro_rules! default_impl {
     };
 }
 
+type IdentificationTuple<T> = (
+    <T as Session>::ValidatorId,
+    pallet_staking::Exposure<<T as System>::AccountId, <T as Balances>::Balance>
+);
+
 /// The trait needed for this module.
 #[module]
-pub trait Session: System {
+pub trait Session: System + Balances {
+    #![event_alias(IdentificationTuple = IdentificationTuple<T>)]
+    #![event_alias(OpaqueTimeSlot = Vec<u8>)]
+    #![event_alias(SessionIndex = u32)]
+
     /// The validator account identifier type for the runtime.
     type ValidatorId: Parameter + Debug + Ord + Default + Send + Sync + 'static;
 

--- a/src/frame/staking.rs
+++ b/src/frame/staking.rs
@@ -63,7 +63,7 @@ pub struct SetPayeeCall<T: Staking> {
 }
 
 /// Identity of a Grandpa authority.
-pub type AuthorityId = [u8; 32];
+pub type AuthorityId = crate::runtimes::app::grandpa::Public;
 /// The weight of an authority.
 pub type AuthorityWeight = u64;
 /// A list of Grandpa authorities with associated weights.

--- a/src/frame/staking.rs
+++ b/src/frame/staking.rs
@@ -66,8 +66,8 @@ pub struct SetPayeeCall<T: Staking> {
 
 /// The subset of the `frame::Trait` that a client must implement.
 #[module]
+#[rustfmt::skip]
 pub trait Staking: Balances {
-    #![rustfmt::skip]
     #![event_alias(ElectionCompute = u8)]
     #![event_type(EraIndex)]
     #![event_type(AuthorityList)]

--- a/src/frame/staking.rs
+++ b/src/frame/staking.rs
@@ -31,8 +31,6 @@ use std::{
     marker::PhantomData,
 };
 
-use sp_finality_grandpa::AuthorityList;
-
 pub use pallet_staking::{
     ActiveEraInfo,
     EraIndex,
@@ -63,6 +61,13 @@ pub struct SetPayeeCall<T: Staking> {
     /// Marker for the runtime
     pub _runtime: PhantomData<T>,
 }
+
+/// Identity of a Grandpa authority.
+pub type AuthorityId = [u8; 32];
+/// The weight of an authority.
+pub type AuthorityWeight = u64;
+/// A list of Grandpa authorities with associated weights.
+pub type AuthorityList = Vec<(AuthorityId, AuthorityWeight)>;
 
 /// The subset of the `frame::Trait` that a client must implement.
 #[module]

--- a/src/frame/staking.rs
+++ b/src/frame/staking.rs
@@ -44,7 +44,6 @@ pub use pallet_staking::{
     ValidatorPrefs,
 };
 
-
 /// Rewards for the last `HISTORY_DEPTH` eras.
 /// If reward hasn't been set or has been removed then 0 reward is returned.
 #[derive(Clone, Encode, Decode, Debug, Store)]
@@ -68,6 +67,7 @@ pub struct SetPayeeCall<T: Staking> {
 /// The subset of the `frame::Trait` that a client must implement.
 #[module]
 pub trait Staking: Balances {
+    #![rustfmt::skip]
     #![event_alias(ElectionCompute = u8)]
     #![event_type(EraIndex)]
     #![event_type(AuthorityList)]

--- a/src/frame/staking.rs
+++ b/src/frame/staking.rs
@@ -31,6 +31,8 @@ use std::{
     marker::PhantomData,
 };
 
+use sp_finality_grandpa::AuthorityList;
+
 pub use pallet_staking::{
     ActiveEraInfo,
     EraIndex,
@@ -41,6 +43,7 @@ pub use pallet_staking::{
     StakingLedger,
     ValidatorPrefs,
 };
+
 
 /// Rewards for the last `HISTORY_DEPTH` eras.
 /// If reward hasn't been set or has been removed then 0 reward is returned.
@@ -64,7 +67,11 @@ pub struct SetPayeeCall<T: Staking> {
 
 /// The subset of the `frame::Trait` that a client must implement.
 #[module]
-pub trait Staking: Balances {}
+pub trait Staking: Balances {
+    #![event_alias(ElectionCompute = u8)]
+    #![event_type(EraIndex)]
+    #![event_type(AuthorityList)]
+}
 
 /// Number of eras to keep in history.
 ///


### PR DESCRIPTION
Fixes #196, fixes #181, fixes #28

## Dynamic sized types

Before this change, the event decoder assume all the event types have fixed sizes. Some counterexamples are: Hashes, AuthorityList.

In this change, instead of decoding by skipping the fixed-length bytes, we introduce `type_segmenter` registry which decodes the raw event bytes with the actual scale codec. So variable length types can be handled correctly.

## New attribute for pallet type definition

In the past, trait associated type is the only way to add types to the EventsDecoder implementation of a pallet. But in reality it's common that the events in a pallet references some types not defined in the trait associated types. Some examples are: `IdentificationTuple` and `SessionIndex` in Session pallet.

In this change, we introduce more attributes to add the types:

```rust
#[module]
trait Pallet: System {
    #![event_type(SomeType)]
    #![event_alias(TypeNameAlias = SomeType)]
    #![event_alias(SomeOtherAlias = TypeWithAssociatedTypes<T>)]
}
```

## Tested

Compile with `nightly-2020-10-01`; smoke test to sync a full
Phala bockchain.