### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Version 0.14.0 (2021-02-05)
+* Refactor event type decoding and declaration [#221](https://github.com/paritytech/substrate-subxt/pull/221)
+* Add Balances Locks [#197](https://github.com/paritytech/substrate-subxt/pull/197)
+* Add event Phase::Initialization [#215](https://github.com/paritytech/substrate-subxt/pull/215)
+* Make type explicit [#217](https://github.com/paritytech/substrate-subxt/pull/217)
+* Upgrade dependencies, bumps substrate to 2.0.1 [#219](https://github.com/paritytech/substrate-subxt/pull/219)
+* Export extra types [#212](https://github.com/paritytech/substrate-subxt/pull/212)
+* Enable retrieval of constants from rutnime metadata [#207](https://github.com/paritytech/substrate-subxt/pull/207)
+* register type sizes for u64 and u128 [#200](https://github.com/paritytech/substrate-subxt/pull/200)
+* Remove some substrate dependencies to improve compile time [#194](https://github.com/paritytech/substrate-subxt/pull/194)
+* propagate 'RuntimeError's to 'decode_raw_bytes' caller [#189](https://github.com/paritytech/substrate-subxt/pull/189)
+* Derive `Clone` for `PairSigner` [#184](https://github.com/paritytech/substrate-subxt/pull/184)
+
 # Version 0.13.0
 * Make the contract call extrinsic work [#165](https://github.com/paritytech/substrate-subxt/pull/165)
 * Update to Substrate 2.0.0 [#173](https://github.com/paritytech/substrate-subxt/pull/173)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "client", "proc-macro", "test-node"]
 
 [package]
 name = "substrate-subxt"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -47,7 +47,7 @@ pallet-staking = "2.0.1"
 sp-rpc = { version = "2.0.1", package = "sp-rpc" }
 sp-core = { version = "2.0.1", package = "sp-core" }
 substrate-subxt-client = { version = "0.5.0", path = "client", optional = true }
-substrate-subxt-proc-macro = { version = "0.13.0", path = "proc-macro" }
+substrate-subxt-proc-macro = { version = "0.14.0", path = "proc-macro" }
 
 [dev-dependencies]
 async-std = { version = "1.8.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ pallet-staking = "2.0.1"
 
 sp-rpc = { version = "2.0.1", package = "sp-rpc" }
 sp-core = { version = "2.0.1", package = "sp-core" }
-substrate-subxt-client = { version = "0.5.0", path = "client", optional = true }
+substrate-subxt-client = { version = "0.6.0", path = "client", optional = true }
 substrate-subxt-proc-macro = { version = "0.14.0", path = "proc-macro" }
 
 [dev-dependencies]
@@ -55,7 +55,7 @@ env_logger = "0.8.2"
 frame-system = "2.0.1"
 pallet-balances = "2.0.1"
 sp-keyring = "2.0.1"
-substrate-subxt-client = { version = "0.5.0", path = "client" }
+substrate-subxt-client = { version = "0.6.0", path = "client" }
 tempdir = "0.3.7"
 test-node = { path = "test-node" }
 wabt = "0.10.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-client"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-proc-macro"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 autotests = false


### PR DESCRIPTION
* Refactor event type decoding and declaration [#221](https://github.com/paritytech/substrate-subxt/pull/221)
* Add Balances Locks [#197](https://github.com/paritytech/substrate-subxt/pull/197)
* Add event Phase::Initialization [#215](https://github.com/paritytech/substrate-subxt/pull/215)
* Make type explicit [#217](https://github.com/paritytech/substrate-subxt/pull/217)
* Upgrade dependencies, bumps substrate to 2.0.1 [#219](https://github.com/paritytech/substrate-subxt/pull/219)
* Export extra types [#212](https://github.com/paritytech/substrate-subxt/pull/212)
* Enable retrieval of constants from rutnime metadata [#207](https://github.com/paritytech/substrate-subxt/pull/207)
* register type sizes for u64 and u128 [#200](https://github.com/paritytech/substrate-subxt/pull/200)
* Remove some substrate dependencies to improve compile time [#194](https://github.com/paritytech/substrate-subxt/pull/194)
* propagate 'RuntimeError's to 'decode_raw_bytes' caller [#189](https://github.com/paritytech/substrate-subxt/pull/189)
* Derive `Clone` for `PairSigner` [#184](https://github.com/paritytech/substrate-subxt/pull/184)