### PR TITLE
rpc client methods should be public for downstream usage

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -171,7 +171,7 @@ pub enum RpcClient {
 }
 
 impl RpcClient {
-    async fn request<T: DeserializeOwned>(
+    pub async fn request<T: DeserializeOwned>(
         &self,
         method: &str,
         params: Params,
@@ -186,7 +186,7 @@ impl RpcClient {
         }
     }
 
-    async fn subscribe<T: DeserializeOwned>(
+    pub async fn subscribe<T: DeserializeOwned>(
         &self,
         subscribe_method: &str,
         params: Params,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>