### PR TITLE
Fix 'Option' return of storage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use codec::{
     Codec,
     Decode,
 };
+use frame_metadata::StorageEntryModifier;
 use futures::future;
 use jsonrpsee_http_client::{
     HttpClient,
@@ -360,8 +361,12 @@ impl<T: Runtime> Client<T> {
         &self,
         key: StorageKey,
         hash: Option<T::Hash>,
+        modifier: StorageEntryModifier,
     ) -> Result<Option<V>, Error> {
-        if let Some(data) = self.rpc.storage(&key, hash).await? {
+        if let Some(mut data) = self.rpc.storage(&key, hash).await? {
+            if modifier == StorageEntryModifier::Optional {
+                data.0.insert(0, 1u8)
+            }
             Ok(Some(Decode::decode(&mut &data.0[..])?))
         } else {
             Ok(None)
@@ -375,7 +380,9 @@ impl<T: Runtime> Client<T> {
         hash: Option<T::Hash>,
     ) -> Result<Option<F::Returns>, Error> {
         let key = store.key(&self.metadata)?;
-        self.fetch_unhashed::<F::Returns>(key, hash).await
+        let storage_meta = self.metadata.module(F::MODULE)?.storage(F::FIELD)?;
+        self.fetch_unhashed::<F::Returns>(key, hash, storage_meta.modifier())
+            .await
     }
 
     /// Fetch a StorageKey that has a default value with an optional block hash.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -273,6 +273,10 @@ impl StorageMetadata {
         StorageKey(bytes)
     }
 
+    pub fn modifier(&self) -> StorageEntryModifier {
+        self.modifier.clone()
+    }
+
     pub fn default<V: Decode>(&self) -> Result<V, MetadataError> {
         Decode::decode(&mut &self.default[..]).map_err(MetadataError::DefaultError)
     }


### PR DESCRIPTION
Renew old PR #210 

For example

For a storage that has a return type `Option<Vec<u8>>`, the storage data through RPC will returns:
- `0x00` for `Some([])`
- `0x080001` for `Some([0, 1])`

So, if subxt want to use the `Option<Vec<u8>>` to decode the returns, the hex should be changed to:
- `0x00` to `0x0100`
- `0x080001` to `0x01080001`  

which is prefixed with a `01` for scale codec `Some`

Or, find a way to use `Vec<u8>` to decode.