### PR TITLE
[jsonrpsee http client]: support tokio1 & tokio02.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.24"
 futures = "0.3.13"
 jsonrpsee-types = "=0.2.0-alpha.3"
 jsonrpsee-ws-client = "=0.2.0-alpha.3"
-jsonrpsee-http-client = { version = "=0.2.0-alpha.3", default-features = false, optional = true }
+jsonrpsee-http-client = { version = "=0.2.0-alpha.3", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ keywords = ["parity", "substrate", "blockchain"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [features]
-default = []
+default = ["tokio1"]
 client = ["substrate-subxt-client"]
+# jsonrpsee http client can be configured to use tokio02 or tokio1.
+tokio02 = ["jsonrpsee-http-client/tokio02"]
+tokio1 = ["jsonrpsee-http-client/tokio1"]
 
 [dependencies]
 log = "0.4.14"
@@ -26,7 +29,7 @@ thiserror = "1.0.24"
 futures = "0.3.13"
 jsonrpsee-types = "=0.2.0-alpha.3"
 jsonrpsee-ws-client = "=0.2.0-alpha.3"
-jsonrpsee-http-client = "=0.2.0-alpha.3"
+jsonrpsee-http-client = { version = "=0.2.0-alpha.3", default-features = false, optional = true }
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"


### PR DESCRIPTION
Closes #262 

As `substrate` and some of the Rust ecosystem hasn't updated to `tokio 1` yet, let's make it configurable to support either `tokio0.2` or `tokio 1`.

//cc @akru can you try this to ensure that it actually fixes your issue ^^
