### PR TITLE
update jsonrpsee to 0.2.0-alpha.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ async-trait = "0.1.49"
 log = "0.4.14"
 thiserror = "1.0.24"
 futures = "0.3.13"
-jsonrpsee-proc-macros = "=0.2.0-alpha.5"
-jsonrpsee-ws-client = "=0.2.0-alpha.5"
-jsonrpsee-http-client = { version = "=0.2.0-alpha.5", default-features = false }
+jsonrpsee-proc-macros = "=0.2.0-alpha.6"
+jsonrpsee-ws-client = "=0.2.0-alpha.6"
+jsonrpsee-http-client = { version = "=0.2.0-alpha.6", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = "0.1.49"
 log = "0.4.14"
 thiserror = "1.0.24"
 futures = "0.3.13"
+jsonrpsee-proc-macros = "=0.2.0-alpha.5"
 jsonrpsee-ws-client = "=0.2.0-alpha.5"
 jsonrpsee-http-client = { version = "=0.2.0-alpha.5", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,8 @@ async-trait = "0.1.49"
 log = "0.4.14"
 thiserror = "1.0.24"
 futures = "0.3.13"
-jsonrpsee-types = "=0.2.0-alpha.3"
-jsonrpsee-ws-client = "=0.2.0-alpha.3"
-jsonrpsee-http-client = { version = "=0.2.0-alpha.3", default-features = false }
+jsonrpsee-ws-client = "=0.2.0-alpha.5"
+jsonrpsee-http-client = { version = "=0.2.0-alpha.5", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,8 +15,7 @@ keywords = ["parity", "substrate", "blockchain"]
 async-std = "1.8.0"
 futures = { version = "0.3.9", features = ["compat"], package = "futures" }
 futures01 = { package = "futures", version = "0.1.29" }
-jsonrpsee-types = "=0.2.0-alpha.3"
-jsonrpsee-ws-client = "=0.2.0-alpha.3"
+jsonrpsee-types = "=0.2.0-alpha.5"
 log = "0.4.13"
 sc-network = { version = "0.9.0", default-features = false }
 sc-client-db = "0.9.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["parity", "substrate", "blockchain"]
 async-std = "1.8.0"
 futures = { version = "0.3.9", features = ["compat"], package = "futures" }
 futures01 = { package = "futures", version = "0.1.29" }
-jsonrpsee-types = "=0.2.0-alpha.5"
+jsonrpsee-types = "=0.2.0-alpha.3"
 log = "0.4.13"
 sc-network = { version = "0.9.0", default-features = false }
 sc-client-db = "0.9.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["parity", "substrate", "blockchain"]
 async-std = "1.8.0"
 futures = { version = "0.3.9", features = ["compat"], package = "futures" }
 futures01 = { package = "futures", version = "0.1.29" }
-jsonrpsee-types = "=0.2.0-alpha.3"
+jsonrpsee-types = "=0.2.0-alpha.5"
 log = "0.4.13"
 sc-network = { version = "0.9.0", default-features = false }
 sc-client-db = "0.9.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["parity", "substrate", "blockchain"]
 async-std = "1.8.0"
 futures = { version = "0.3.9", features = ["compat"], package = "futures" }
 futures01 = { package = "futures", version = "0.1.29" }
-jsonrpsee-types = "=0.2.0-alpha.5"
+jsonrpsee-types = "=0.2.0-alpha.6"
 log = "0.4.13"
 sc-network = { version = "0.9.0", default-features = false }
 sc-client-db = "0.9.0"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -40,27 +40,35 @@ use futures::{
 };
 use futures01::sync::mpsc as mpsc01;
 use jsonrpsee_types::{
-    client::{
-        FrontToBack,
-        NotificationMessage,
-        RequestMessage,
-        Subscription,
-        SubscriptionMessage,
+    v2::{
+        error::{
+            ErrorCode,
+            JsonRpcErrorAlloc,
+        },
+        params::{
+            Id,
+            JsonRpcParams,
+            SubscriptionId,
+            TwoPointZero,
+        },
+        parse_request_id,
+        request::{
+            JsonRpcCallSer,
+            JsonRpcInvalidRequest,
+            JsonRpcNotificationSer,
+        },
+        response::{
+            JsonRpcNotifResponse,
+            JsonRpcResponse,
+        },
     },
-    error::Error as JsonRpseeError,
-    jsonrpc::{
-        self,
-        Call,
-        DeserializeOwned,
-        Id,
-        MethodCall,
-        Notification,
-        Output,
-        Request,
-        SubscriptionId,
-        SubscriptionNotif,
-        Version,
-    },
+    DeserializeOwned,
+    Error as JsonRpseeError,
+    FrontToBack,
+    JsonValue,
+    RequestMessage,
+    Subscription,
+    SubscriptionMessage,
 };
 use sc_network::config::TransportConfig;
 pub use sc_service::{
@@ -87,6 +95,10 @@ use sc_service::{
 use std::{
     collections::HashMap,
     marker::PhantomData,
+    sync::atomic::{
+        AtomicU64,
+        Ordering,
+    },
 };
 use thiserror::Error;
 
@@ -107,15 +119,15 @@ pub enum SubxtClientError {
 #[derive(Clone)]
 pub struct SubxtClient {
     to_back: mpsc::Sender<FrontToBack>,
+    next_id: Arc<AtomicU64>,
 }
 
 impl SubxtClient {
     /// Create a new client.
     pub fn new(mut task_manager: TaskManager, rpc: RpcHandlers) -> Self {
         let (to_back, from_front) = mpsc::channel(DEFAULT_CHANNEL_SIZE);
-
-        let request_id = Arc::new(RwLock::new(u64::MIN));
-        let subscriptions = Arc::new(RwLock::new(HashMap::<u64, String>::new()));
+        let subscriptions =
+            Arc::new(RwLock::new(HashMap::<SubscriptionId, (String, Id)>::new()));
 
         task::spawn(
             select(
@@ -124,118 +136,72 @@ impl SubxtClient {
                     let (to_front, from_back) = mpsc01::channel(DEFAULT_CHANNEL_SIZE);
                     let session = RpcSession::new(to_front.clone());
 
-                    let request_id = request_id.clone();
                     let subscriptions = subscriptions.clone();
 
                     async move {
-                        let request_id = {
-                            let mut request_id = request_id.write().await;
-                            *request_id = request_id.wrapping_add(1);
-                            *request_id
-                        };
-
                         match message {
-                            FrontToBack::Notification(NotificationMessage {
-                                method,
-                                params,
-                            }) => {
-                                let request =
-                                    Request::Single(Call::Notification(Notification {
-                                        jsonrpc: Version::V2,
-                                        method,
-                                        params,
-                                    }));
-                                if let Ok(message) = serde_json::to_string(&request) {
-                                    rpc.rpc_query(&session, &message).await;
-                                }
+                            FrontToBack::Notification(raw) => {
+                                let _ = rpc.rpc_query(&session, &raw).await;
                             }
-
-                            FrontToBack::StartRequest(RequestMessage {
-                                method,
-                                params,
+                            FrontToBack::Request(RequestMessage {
+                                raw,
+                                id,
                                 send_back,
                             }) => {
-                                let request =
-                                    Request::Single(Call::MethodCall(MethodCall {
-                                        jsonrpc: Version::V2,
-                                        method: method.into(),
-                                        params: params.into(),
-                                        id: Id::Num(request_id),
-                                    }));
-                                if let Ok(message) = serde_json::to_string(&request) {
-                                    if let Some(response) =
-                                        rpc.rpc_query(&session, &message).await
-                                    {
-                                        let result = match serde_json::from_str::<Output>(
-                                            &response,
-                                        )
-                                        .expect("failed to decode request response")
-                                        {
-                                            Output::Success(success) => {
-                                                Ok(success.result)
-                                            }
-                                            Output::Failure(failure) => {
-                                                Err(JsonRpseeError::Request(
-                                                    failure.error,
-                                                ))
-                                            }
-                                        };
+                                let raw_response = rpc.rpc_query(&session, &raw).await;
+                                let to_front = match read_jsonrpc_response(
+                                    raw_response,
+                                    Id::Number(id),
+                                ) {
+                                    Some(Err(e)) => Err(e),
+                                    Some(Ok(rp)) => Ok(rp),
+                                    None => return,
+                                };
 
-                                        send_back.map(|tx| {
-                                            tx.send(result)
-                                                .expect("failed to send request response")
-                                        });
-                                    }
-                                }
+                                send_back
+                                    .expect("request should have send_back")
+                                    .send(to_front)
+                                    .expect("failed to send request response");
                             }
 
                             FrontToBack::Subscribe(SubscriptionMessage {
-                                subscribe_method,
-                                params,
+                                raw,
+                                subscribe_id,
+                                unsubscribe_id,
                                 unsubscribe_method,
                                 send_back,
                             }) => {
-                                {
-                                    let mut subscriptions = subscriptions.write().await;
-                                    subscriptions.insert(request_id, unsubscribe_method);
-                                }
-
-                                let request =
-                                    Request::Single(Call::MethodCall(MethodCall {
-                                        jsonrpc: Version::V2,
-                                        method: subscribe_method,
-                                        params,
-                                        id: Id::Num(request_id),
-                                    }));
+                                let raw_response = rpc.rpc_query(&session, &raw).await;
+                                let sub_id: SubscriptionId = match read_jsonrpc_response(
+                                    raw_response,
+                                    Id::Number(subscribe_id),
+                                ) {
+                                    Some(Ok(rp)) => {
+                                        serde_json::from_value(rp)
+                                            .expect("infalliable; qed")
+                                    }
+                                    Some(Err(e)) => {
+                                        send_back
+                                            .send(Err(e))
+                                            .expect("failed to send request response");
+                                        return
+                                    }
+                                    None => return,
+                                };
 
                                 let (mut send_front_sub, send_back_sub) =
                                     mpsc::channel(DEFAULT_CHANNEL_SIZE);
-                                if let Ok(message) = serde_json::to_string(&request) {
-                                    if let Some(response) =
-                                        rpc.rpc_query(&session, &message).await
-                                    {
-                                        let result = match serde_json::from_str::<Output>(
-                                            &response,
-                                        )
-                                        .expect("failed to decode subscription response")
-                                        {
-                                            Output::Success(_) => {
-                                                Ok((
-                                                    send_back_sub,
-                                                    SubscriptionId::Num(request_id),
-                                                ))
-                                            }
-                                            Output::Failure(failure) => {
-                                                Err(JsonRpseeError::Request(
-                                                    failure.error,
-                                                ))
-                                            }
-                                        };
 
-                                        send_back.send(result).expect(
-                                            "failed to send subscription response",
-                                        );
-                                    }
+                                send_back
+                                    .send(Ok((send_back_sub, sub_id.clone())))
+                                    .expect("failed to send request response");
+
+                                {
+                                    let mut subscriptions = subscriptions.write().await;
+                                    subscriptions.insert(
+                                        sub_id.clone(),
+                                        (unsubscribe_method, Id::Number(unsubscribe_id)),
+                                    );
                                 }
 
                                 task::spawn(async move {
@@ -245,7 +211,7 @@ impl SubxtClient {
                                     while let Some(Ok(response)) = from_back.next().await
                                     {
                                         let notif = serde_json::from_str::<
-                                            SubscriptionNotif,
+                                            JsonRpcNotifResponse<JsonValue>,
                                         >(
                                             &response
                                         )
@@ -258,31 +224,24 @@ impl SubxtClient {
                                 });
                             }
 
-                            FrontToBack::SubscriptionClosed(subscription_id) => {
-                                let sub_id =
-                                    if let SubscriptionId::Num(num) = subscription_id {
-                                        num
-                                    } else {
-                                        unreachable!("subscription id should be num")
-                                    };
-                                let json_sub_id = jsonrpc::to_value(sub_id).unwrap();
+                            FrontToBack::SubscriptionClosed(sub_id) => {
+                                let params: &[JsonValue] = &[sub_id.clone().into()];
 
                                 let subscriptions = subscriptions.read().await;
-                                if let Some(unsubscribe) = subscriptions.get(&sub_id) {
-                                    let request =
-                                        Request::Single(Call::MethodCall(MethodCall {
-                                            jsonrpc: Version::V2,
-                                            method: unsubscribe.into(),
-                                            params: jsonrpc::Params::Array(vec![
-                                                json_sub_id,
-                                            ]),
-                                            id: Id::Num(request_id),
-                                        }));
-                                    if let Ok(message) = serde_json::to_string(&request) {
-                                        rpc.rpc_query(&session, &message).await;
-                                    }
+                                if let Some((unsub_method, unsub_id)) =
+                                    subscriptions.get(&sub_id)
+                                {
+                                    let message =
+                                        serde_json::to_string(&JsonRpcCallSer::new(
+                                            unsub_id.clone(),
+                                            unsub_method,
+                                            params.into(),
+                                        ))
+                                        .unwrap();
+                                    let _ = rpc.rpc_query(&session, &message).await;
                                 }
                             }
+                            FrontToBack::Batch(_) => (),
                         }
                     }
                 })),
@@ -293,7 +252,10 @@ impl SubxtClient {
             .map(drop),
         );
 
-        Self { to_back }
+        Self {
+            to_back,
+            next_id: Arc::new(AtomicU64::new(0)),
+        }
     }
 
     /// Creates a new client from a config.
@@ -307,43 +269,40 @@ impl SubxtClient {
     }
 
     /// Send a JSONRPC notification.
-    pub async fn notification<M, P>(
+    pub async fn notification<'a>(
         &self,
-        method: M,
-        params: P,
-    ) -> Result<(), JsonRpseeError>
-    where
-        M: Into<String> + Send,
-        P: Into<jsonrpc::Params> + Send,
-    {
+        method: &'a str,
+        params: JsonRpcParams<'a>,
+    ) -> Result<(), JsonRpseeError> {
+        let msg = serde_json::to_string(&JsonRpcNotificationSer::new(method, params))
+            .map_err(JsonRpseeError::ParseError)?;
         self.to_back
             .clone()
-            .send(FrontToBack::Notification(NotificationMessage {
-                method: method.into(),
-                params: params.into(),
-            }))
+            .send(FrontToBack::Notification(msg))
             .await
             .map_err(|e| JsonRpseeError::TransportError(Box::new(e)))
     }
 
     /// Send a JSONRPC request.
-    pub async fn request<T, M, P>(
+    pub async fn request<'a, T>(
         &self,
-        method: M,
-        params: P,
+        method: &'a str,
+        params: JsonRpcParams<'a>,
     ) -> Result<T, JsonRpseeError>
     where
         T: DeserializeOwned,
-        M: Into<String> + Send,
-        P: Into<jsonrpc::Params> + Send,
     {
         let (send_back_tx, send_back_rx) = oneshot::channel();
 
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let msg =
+            serde_json::to_string(&JsonRpcCallSer::new(Id::Number(id), method, params))
+                .map_err(JsonRpseeError::ParseError)?;
         self.to_back
             .clone()
-            .send(FrontToBack::StartRequest(RequestMessage {
-                method: method.into(),
-                params: params.into(),
+            .send(FrontToBack::Request(RequestMessage {
+                raw: msg,
+                id,
                 send_back: Some(send_back_tx),
             }))
             .await
@@ -354,33 +313,36 @@ impl SubxtClient {
             Ok(Err(err)) => return Err(err),
             Err(err) => return Err(JsonRpseeError::TransportError(Box::new(err))),
         };
-        jsonrpc::from_value(json_value).map_err(JsonRpseeError::ParseError)
+        serde_json::from_value(json_value).map_err(JsonRpseeError::ParseError)
     }
 
     /// Send a subscription request to the server.
-    pub async fn subscribe<SM, UM, P, N>(
+    pub async fn subscribe<'a, N>(
         &self,
-        subscribe_method: SM,
-        params: P,
-        unsubscribe_method: UM,
+        subscribe_method: &'a str,
+        params: JsonRpcParams<'a>,
+        unsubscribe_method: &'a str,
     ) -> Result<Subscription<N>, JsonRpseeError>
     where
-        SM: Into<String> + Send,
-        UM: Into<String> + Send,
-        P: Into<jsonrpc::Params> + Send,
         N: DeserializeOwned,
     {
-        let subscribe_method = subscribe_method.into();
-        let unsubscribe_method = unsubscribe_method.into();
-        let params = params.into();
+        let sub_req_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let unsub_req_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let msg = serde_json::to_string(&JsonRpcCallSer::new(
+            Id::Number(sub_req_id),
+            subscribe_method,
+            params,
+        ))
+        .map_err(JsonRpseeError::ParseError)?;
 
         let (send_back_tx, send_back_rx) = oneshot::channel();
         self.to_back
             .clone()
             .send(FrontToBack::Subscribe(SubscriptionMessage {
-                subscribe_method,
-                unsubscribe_method,
-                params,
+                raw: msg,
+                subscribe_id: sub_req_id,
+                unsubscribe_id: unsub_req_id,
+                unsubscribe_method: unsubscribe_method.to_owned(),
                 send_back: send_back_tx,
             }))
             .await
@@ -543,5 +505,33 @@ impl<C: ChainSpec + 'static> SubxtClientConfig<C> {
         log::info!("👤 Role: {:?}", self.role);
 
         service_config
+    }
+}
+
+fn read_jsonrpc_response(
+    maybe_msg: Option<String>,
+    id: Id,
+) -> Option<Result<JsonValue, JsonRpseeError>> {
+    let msg = maybe_msg?;
+    match serde_json::from_str::<JsonRpcResponse<JsonValue>>(&msg) {
+        Ok(rp) => {
+            match parse_request_id::<Id>(rp.id) {
+                Ok(rp_id) if rp_id == id => Some(Ok(rp.result)),
+                _ => Some(Err(JsonRpseeError::InvalidRequestId)),
+            }
+        }
+        Err(_) => {
+            match serde_json::from_str::<JsonRpcInvalidRequest<'_>>(&msg) {
+                Ok(err) => {
+                    let err = JsonRpcErrorAlloc {
+                        jsonrpc: TwoPointZero,
+                        error: ErrorCode::InvalidParams,
+                        id: parse_request_id(err.id).ok()?,
+                    };
+                    Some(Err(JsonRpseeError::Request(err)))
+                }
+                Err(_) => None,
+            }
+        }
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -42,7 +42,7 @@ use futures01::sync::mpsc as mpsc01;
 use jsonrpsee_types::{
     v2::{
         error::{
-            ErrorCode,
+            JsonRpcErrorCode,
             JsonRpcErrorAlloc,
         },
         params::{
@@ -525,7 +525,7 @@ fn read_jsonrpc_response(
                 Ok(err) => {
                     let err = JsonRpcErrorAlloc {
                         jsonrpc: TwoPointZero,
-                        error: ErrorCode::InvalidParams,
+                        error: JsonRpcErrorCode::InvalidRequest.into(),
                         id: parse_request_id(err.id).ok()?,
                     };
                     Some(Err(JsonRpseeError::Request(err)))

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -42,8 +42,8 @@ use futures01::sync::mpsc as mpsc01;
 use jsonrpsee_types::{
     v2::{
         error::{
-            JsonRpcErrorCode,
             JsonRpcErrorAlloc,
+            JsonRpcErrorCode,
         },
         params::{
             Id,

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use jsonrpsee_types::error::Error as RequestError;
+use jsonrpsee_ws_client::Error as RequestError;
 use sp_core::crypto::SecretStringError;
 use sp_runtime::{
     transaction_validity::TransactionValidityError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,14 +51,10 @@ use codec::{
     Decode,
 };
 use futures::future;
-use jsonrpsee_http_client::{
-    HttpClient,
-    HttpConfig,
-};
+use jsonrpsee_http_client::HttpClientBuilder;
 use jsonrpsee_ws_client::{
-    WsClient,
-    WsConfig,
-    WsSubscription as Subscription,
+    Subscription,
+    WsClientBuilder,
 };
 use sp_core::{
     storage::{
@@ -212,11 +208,13 @@ impl<T: Runtime> ClientBuilder<T> {
         } else {
             let url = self.url.as_deref().unwrap_or("ws://127.0.0.1:9944");
             if url.starts_with("ws://") || url.starts_with("wss://") {
-                let mut config = WsConfig::with_url(&url);
-                config.max_notifs_per_subscription = 4096;
-                RpcClient::WebSocket(Arc::new(WsClient::new(config).await?))
+                let client = WsClientBuilder::default()
+                    .max_notifs_per_subscription(4096)
+                    .build(&url)
+                    .await?;
+                RpcClient::WebSocket(Arc::new(client))
             } else {
-                let client = HttpClient::new(url, HttpConfig::default())?;
+                let client = HttpClientBuilder::default().build(&url)?;
                 RpcClient::Http(Arc::new(client))
             }
         };
@@ -505,7 +503,7 @@ impl<T: Runtime> Client<T> {
 
     /// Subscribe to new blocks.
     pub async fn subscribe_blocks(&self) -> Result<Subscription<T::Header>, Error> {
-        let headers = self.rpc.subscribe_blocks().await?;
+        let headers: Subscription<T::Header> = self.rpc.subscribe_blocks().await?;
         Ok(headers)
     }
 
@@ -513,7 +511,8 @@ impl<T: Runtime> Client<T> {
     pub async fn subscribe_finalized_blocks(
         &self,
     ) -> Result<Subscription<T::Header>, Error> {
-        let headers = self.rpc.subscribe_finalized_blocks().await?;
+        let headers: Subscription<T::Header> =
+            self.rpc.subscribe_finalized_blocks().await?;
         Ok(headers)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ impl<T: Runtime> Client<T> {
 
     /// Subscribe to new blocks.
     pub async fn subscribe_blocks(&self) -> Result<Subscription<T::Header>, Error> {
-        let headers: Subscription<T::Header> = self.rpc.subscribe_blocks().await?;
+        let headers = self.rpc.subscribe_blocks().await?;
         Ok(headers)
     }
 
@@ -511,8 +511,7 @@ impl<T: Runtime> Client<T> {
     pub async fn subscribe_finalized_blocks(
         &self,
     ) -> Result<Subscription<T::Header>, Error> {
-        let headers: Subscription<T::Header> =
-            self.rpc.subscribe_finalized_blocks().await?;
+        let headers = self.rpc.subscribe_finalized_blocks().await?;
         Ok(headers)
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -473,7 +473,7 @@ impl<T: Runtime> Rpc<T> {
         let keys = Some(vec![StorageKey::from(SystemEvents::new())]);
         let params: &[_] = &[to_json_value(keys)?];
 
-        let subscription: Subscription<StorageChangeSet<T::Hash>> = self
+        let subscription = self
             .client
             .subscribe(
                 "state_subscribeStorage",

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -412,8 +412,8 @@ impl<T: Runtime> Rpc<T> {
         &self,
         hash: Option<T::Hash>,
     ) -> Result<Option<ChainBlock<T>>, Error> {
-        let params: &[_] = &[to_json_value(hash)?];
-        let block = self.client.request("chain_getBlock", params.into()).await?;
+        let params = &[to_json_value(hash)?];
+        let block = self.client.request("chain_getBlock", params).await?;
         Ok(block)
     }
 
@@ -423,10 +423,10 @@ impl<T: Runtime> Rpc<T> {
         keys: Vec<StorageKey>,
         hash: Option<T::Hash>,
     ) -> Result<ReadProof<T::Hash>, Error> {
-        let params: &[_] = &[to_json_value(keys)?, to_json_value(hash)?];
+        let params = &[to_json_value(keys)?, to_json_value(hash)?];
         let proof = self
             .client
-            .request("state_getReadProof", params.into())
+            .request("state_getReadProof", params)
             .await?;
         Ok(proof)
     }
@@ -436,10 +436,10 @@ impl<T: Runtime> Rpc<T> {
         &self,
         at: Option<T::Hash>,
     ) -> Result<RuntimeVersion, Error> {
-        let params: &[_] = &[to_json_value(at)?];
+        let params = &[to_json_value(at)?];
         let version = self
             .client
-            .request("state_getRuntimeVersion", params.into())
+            .request("state_getRuntimeVersion", params)
             .await?;
         Ok(version)
     }
@@ -450,13 +450,13 @@ impl<T: Runtime> Rpc<T> {
     /// `subscribe_finalized_events` to ensure events are finalized.
     pub async fn subscribe_events(&self) -> Result<EventStorageSubscription<T>, Error> {
         let keys = Some(vec![StorageKey::from(SystemEvents::new())]);
-        let params: &[_] = &[to_json_value(keys)?];
+        let params = &[to_json_value(keys)?];
 
         let subscription = self
             .client
             .subscribe(
                 "state_subscribeStorage",
-                params.into(),
+                params,
                 "state_unsubscribeStorage",
             )
             .await?;
@@ -506,10 +506,10 @@ impl<T: Runtime> Rpc<T> {
         extrinsic: E,
     ) -> Result<T::Hash, Error> {
         let bytes: Bytes = extrinsic.encode().into();
-        let params: &[_] = &[to_json_value(bytes)?];
+        let params = &[to_json_value(bytes)?];
         let xt_hash = self
             .client
-            .request("author_submitExtrinsic", params.into())
+            .request("author_submitExtrinsic", params)
             .await?;
         Ok(xt_hash)
     }
@@ -519,12 +519,12 @@ impl<T: Runtime> Rpc<T> {
         extrinsic: E,
     ) -> Result<Subscription<TransactionStatus<T::Hash, T::Hash>>, Error> {
         let bytes: Bytes = extrinsic.encode().into();
-        let params: &[_] = &[to_json_value(bytes)?];
+        let params = &[to_json_value(bytes)?];
         let subscription = self
             .client
             .subscribe(
                 "author_submitAndWatchExtrinsic",
-                params.into(),
+                params,
                 "author_unwatchExtrinsic",
             )
             .await?;
@@ -633,13 +633,13 @@ impl<T: Runtime> Rpc<T> {
         suri: String,
         public: Bytes,
     ) -> Result<(), Error> {
-        let params: &[_] = &[
+        let params = &[
             to_json_value(key_type)?,
             to_json_value(suri)?,
             to_json_value(public)?,
         ];
         self.client
-            .request("author_insertKey", params.into())
+            .request("author_insertKey", params)
             .await?;
         Ok(())
     }
@@ -655,10 +655,10 @@ impl<T: Runtime> Rpc<T> {
     ///
     /// Returns `true` iff all private keys could be found.
     pub async fn has_session_keys(&self, session_keys: Bytes) -> Result<bool, Error> {
-        let params: &[_] = &[to_json_value(session_keys)?];
+        let params = &[to_json_value(session_keys)?];
         Ok(self
             .client
-            .request("author_hasSessionKeys", params.into())
+            .request("author_hasSessionKeys", params)
             .await?)
     }
 
@@ -670,7 +670,7 @@ impl<T: Runtime> Rpc<T> {
         public_key: Bytes,
         key_type: String,
     ) -> Result<bool, Error> {
-        let params: &[_] = &[to_json_value(public_key)?, to_json_value(key_type)?];
+        let params = &[to_json_value(public_key)?, to_json_value(key_type)?];
         Ok(self.client.request("author_hasKey", params.into()).await?)
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -424,10 +424,7 @@ impl<T: Runtime> Rpc<T> {
         hash: Option<T::Hash>,
     ) -> Result<ReadProof<T::Hash>, Error> {
         let params = &[to_json_value(keys)?, to_json_value(hash)?];
-        let proof = self
-            .client
-            .request("state_getReadProof", params)
-            .await?;
+        let proof = self.client.request("state_getReadProof", params).await?;
         Ok(proof)
     }
 
@@ -454,11 +451,7 @@ impl<T: Runtime> Rpc<T> {
 
         let subscription = self
             .client
-            .subscribe(
-                "state_subscribeStorage",
-                params,
-                "state_unsubscribeStorage",
-            )
+            .subscribe("state_subscribeStorage", params, "state_unsubscribeStorage")
             .await?;
         Ok(EventStorageSubscription::Imported(subscription))
     }
@@ -638,9 +631,7 @@ impl<T: Runtime> Rpc<T> {
             to_json_value(suri)?,
             to_json_value(public)?,
         ];
-        self.client
-            .request("author_insertKey", params)
-            .await?;
+        self.client.request("author_insertKey", params).await?;
         Ok(())
     }
 
@@ -656,10 +647,7 @@ impl<T: Runtime> Rpc<T> {
     /// Returns `true` iff all private keys could be found.
     pub async fn has_session_keys(&self, session_keys: Bytes) -> Result<bool, Error> {
         let params = &[to_json_value(session_keys)?];
-        Ok(self
-            .client
-            .request("author_hasSessionKeys", params)
-            .await?)
+        Ok(self.client.request("author_hasSessionKeys", params).await?)
     }
 
     /// Checks if the keystore has private keys for the given public key and key type.
@@ -671,7 +659,7 @@ impl<T: Runtime> Rpc<T> {
         key_type: String,
     ) -> Result<bool, Error> {
         let params = &[to_json_value(public_key)?, to_json_value(key_type)?];
-        Ok(self.client.request("author_hasKey", params.into()).await?)
+        Ok(self.client.request("author_hasKey", params).await?)
     }
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -408,10 +408,10 @@ impl<T: Runtime> Rpc<T> {
         block_number: Option<BlockNumber>,
     ) -> Result<Option<T::Hash>, Error> {
         let block_number = block_number.map(ListOrValue::Value);
-        let params = [to_json_value(block_number)?];
+        let params: &[_] = &[to_json_value(block_number)?];
         let list_or_value = self
             .client
-            .request("chain_getBlockHash", (&params[..]).into())
+            .request("chain_getBlockHash", params.into())
             .await?;
         match list_or_value {
             ListOrValue::Value(hash) => Ok(hash),
@@ -433,11 +433,8 @@ impl<T: Runtime> Rpc<T> {
         &self,
         hash: Option<T::Hash>,
     ) -> Result<Option<ChainBlock<T>>, Error> {
-        let params = [to_json_value(hash)?];
-        let block = self
-            .client
-            .request("chain_getBlock", (&params[..]).into())
-            .await?;
+        let params: &[_] = &[to_json_value(hash)?];
+        let block = self.client.request("chain_getBlock", params.into()).await?;
         Ok(block)
     }
 
@@ -447,10 +444,10 @@ impl<T: Runtime> Rpc<T> {
         keys: Vec<StorageKey>,
         hash: Option<T::Hash>,
     ) -> Result<ReadProof<T::Hash>, Error> {
-        let params = [to_json_value(keys)?, to_json_value(hash)?];
+        let params: &[_] = &[to_json_value(keys)?, to_json_value(hash)?];
         let proof = self
             .client
-            .request("state_getReadProof", (&params[..]).into())
+            .request("state_getReadProof", params.into())
             .await?;
         Ok(proof)
     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use jsonrpsee_ws_client::WsSubscription as Subscription;
+use jsonrpsee_ws_client::Subscription;
 use sp_core::{
     storage::{
         StorageChangeSet,


### PR DESCRIPTION
The rationale is behind this bump is https://github.com/paritytech/jsonrpsee/pull/274 and that the client API has been changed to avoid less allocations.

Also we have released the `jsonrpsee root` crate again but it doesn't expose `tokio02` feature to won't work for this repo yet :(
