### PR TITLE
Expose the rpc client in Client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,6 +355,11 @@ impl<T: Runtime> Client<T> {
         &self.properties
     }
 
+    /// Returns the rpc client.
+    pub fn rpc_client(&self) -> &RpcClient {
+        &self.rpc.client
+    }
+
     /// Fetch the value under an unhashed storage key
     pub async fn fetch_unhashed<V: Decode>(
         &self,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -258,7 +258,8 @@ pub struct ReadProof<Hash> {
 
 /// Client for substrate rpc interfaces
 pub struct Rpc<T: Runtime> {
-    client: RpcClient,
+    /// Rpc client for sending requests.
+    pub client: RpcClient,
     marker: PhantomData<T>,
     accept_weak_inclusion: bool,
 }


### PR DESCRIPTION
This makes the life of the downstream user easier.

With `Client`, we can only access the public methods exposed in it
but that does not cover all the RPC interfaces provided by the chain.
Therefore, the user of this library has to build another `RpcClient` for
the uncovered RPC interfaces, which can be unnecessary.