### PR TITLE
Update to substrate master

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: download-substrate
       run: |
-          curl "https://releases.parity.io/substrate/x86_64-debian:stretch/v3.0.0/substrate/substrate" --output substrate --location
+          curl "https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate/substrate" --output substrate --location
           chmod +x ./substrate
           mkdir -p ~/.local/bin
           mv substrate ~/.local/bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio1 = ["jsonrpsee-http-client/tokio1"]
 
 [dependencies]
 async-trait = "0.1.49"
+hex = "0.4.3"
 log = "0.4.14"
 thiserror = "1.0.24"
 futures = "0.3.13"
@@ -38,28 +39,28 @@ url = "2.2.1"
 codec = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 dyn-clone = "1.0.4"
 
-frame-metadata = "13.0.0"
-frame-support = "3.0.0"
-sp-runtime = "3.0.0"
-sp-version = "3.0.0"
-pallet-indices = "3.0.0"
-hex = "0.4.3"
-sp-std = "3.0.0"
-application-crypto = { version = "3.0.0", package = "sp-application-crypto" }
-pallet-staking = "3.0.0"
+frame-metadata = { package = "frame-metadata", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+frame-support = { package = "frame-support", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+pallet-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+pallet-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-rpc = { package = "sp-rpc", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
 
-sp-rpc = { version = "3.0.0", package = "sp-rpc" }
-sp-core = { version = "3.0.0", package = "sp-core" }
 substrate-subxt-client = { version = "0.7.0", path = "client", optional = true }
 substrate-subxt-proc-macro = { version = "0.15.0", path = "proc-macro" }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
 env_logger = "0.8.3"
-frame-system = "3.0.0"
-pallet-balances = "3.0.0"
-sp-keyring = "3.0.0"
 tempdir = "0.3.7"
 wabt = "0.10.0"
 which = "4.0.2"
 assert_matches = "1.5.0"
+
+frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+pallet-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,17 @@ url = "2.2.1"
 substrate-subxt-client = { version = "0.7.0", path = "client", optional = true }
 substrate-subxt-proc-macro = { version = "0.15.0", path = "proc-macro" }
 
-sp-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-rpc = { package = "sp-rpc", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-rpc = { package = "sp-rpc", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "master" }
 
-frame-metadata = { package = "frame-metadata", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-frame-support = { package = "frame-support", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-pallet-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-pallet-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+frame-metadata = { package = "frame-metadata", git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-support = { package = "frame-support", git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
@@ -63,6 +63,6 @@ tempdir = "0.3.7"
 wabt = "0.10.0"
 which = "4.0.2"
 
-frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-pallet-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,15 +18,16 @@ futures01 = { package = "futures", version = "0.1.29" }
 jsonrpsee-types = "=0.2.0-alpha.3"
 jsonrpsee-ws-client = "=0.2.0-alpha.3"
 log = "0.4.13"
-sc-network = { version = "0.9.0", default-features = false }
-sc-client-db = "0.9.0"
-sc-service = { version = "0.9.0", default-features = false }
 serde_json = "1.0.61"
-sp-keyring = "3.0.0"
 thiserror = "1.0.23"
 
+sc-network = { package = "sc-network", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c", default-features = false }
+sc-client-db = { package = "sc-client-db", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sc-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c", default-features = false }
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+
 [target.'cfg(target_arch="x86_64")'.dependencies]
-sc-service = { version = "0.9.0", default-features = false, features = ["wasmtime"] }
+sc-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c", default-features = false, features = ["wasmtime"] }
 
 [dev-dependencies]
 async-std = { version = "1.8.0", features = ["attributes"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,13 +20,13 @@ log = "0.4.13"
 serde_json = "1.0.61"
 thiserror = "1.0.23"
 
-sc-client-db = { package = "sc-client-db", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
-sc-network = { package = "sc-network", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c", default-features = false }
-sc-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c", default-features = false }
+sc-client-db = { package = "sc-client-db", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { package = "sc-network", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sc-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
-sc-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c", default-features = false, features = ["wasmtime"] }
+sc-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = ["wasmtime"] }
 
 [dev-dependencies]
 async-std = { version = "1.8.0", features = ["attributes"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -373,11 +373,7 @@ impl From<Role> for sc_service::Role {
     fn from(role: Role) -> Self {
         match role {
             Role::Light => Self::Light,
-            Role::Authority(_) => {
-                Self::Authority {
-                    sentry_nodes: Default::default(),
-                }
-            }
+            Role::Authority(_) => Self::Authority,
         }
     }
 }
@@ -462,8 +458,6 @@ impl<C: ChainSpec + 'static> SubxtClientConfig<C> {
             telemetry_endpoints,
 
             telemetry_external_transport: Default::default(),
-            telemetry_handle: Default::default(),
-            telemetry_span: Default::default(),
             default_heap_pages: Default::default(),
             disable_grandpa: Default::default(),
             disable_log_reloading: Default::default(),
@@ -478,6 +472,7 @@ impl<C: ChainSpec + 'static> SubxtClientConfig<C> {
             rpc_ipc: Default::default(),
             rpc_ws: Default::default(),
             rpc_ws_max_connections: Default::default(),
+            rpc_http_threads: Default::default(),
             rpc_methods: Default::default(),
             state_cache_child_ratio: Default::default(),
             state_cache_size: Default::default(),

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -29,7 +29,7 @@ async-std = { version = "1.8.0", features = ["attributes"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 env_logger = "0.8.2"
 pretty_assertions = "0.6.1"
-sp-keyring = "3.0.0"
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
 substrate-subxt = { path = ".." }
 trybuild = "1.0.38"
 

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -32,7 +32,7 @@ pretty_assertions = "0.6.1"
 substrate-subxt = { path = ".." }
 trybuild = "1.0.38"
 
-sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", rev = "eb9033b826b9e8115c20707fe66af0ceb177e99c" }
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [[test]]
 name = "balances"

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ use jsonrpsee_ws_client::Error as RequestError;
 use sp_core::crypto::SecretStringError;
 use sp_runtime::{
     transaction_validity::TransactionValidityError,
-    DispatchError,
+    DispatchError, TokenError, ArithmeticError,
 };
 use thiserror::Error;
 
@@ -111,6 +111,12 @@ pub enum RuntimeError {
     /// Cannot lookup.
     #[error("Cannot lookup some information required to validate the transaction.")]
     CannotLookup,
+    /// An error to do with tokens.
+    #[error("An error to do with tokens. {0:?}")]
+    Token(TokenError),
+    /// An arithmetic error.
+    #[error("An arithmetic error. {0:?}")]
+    Arithmetic(ArithmeticError),
     /// Other error.
     #[error("Other error: {0}")]
     Other(String),
@@ -134,7 +140,9 @@ impl RuntimeError {
                     module: module.name().to_string(),
                     error: error.to_string(),
                 }))
-            }
+            },
+            DispatchError::Token(err) => Ok(Self::Token(err)),
+            DispatchError::Arithmetic(err) => Ok(Self::Arithmetic(err)),
             DispatchError::BadOrigin => Ok(Self::BadOrigin),
             DispatchError::CannotLookup => Ok(Self::CannotLookup),
             DispatchError::ConsumerRemaining => Ok(Self::ConsumerRemaining),

--- a/src/events.rs
+++ b/src/events.rs
@@ -361,7 +361,7 @@ mod tests {
         ModuleMetadata,
         RuntimeMetadata,
         RuntimeMetadataPrefixed,
-        RuntimeMetadataV12,
+        RuntimeMetadataV13,
         META_RESERVED,
     };
     use std::convert::TryFrom;
@@ -399,7 +399,7 @@ mod tests {
         let decoder = EventsDecoder::<TestRuntime>::new(
             Metadata::try_from(RuntimeMetadataPrefixed(
                 META_RESERVED,
-                RuntimeMetadata::V12(RuntimeMetadataV12 {
+                RuntimeMetadata::V13(RuntimeMetadataV13 {
                     modules: DecodeDifferent::Decoded(vec![ModuleMetadata {
                         name: DecodeDifferent::Decoded("System".to_string()),
                         storage: None,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -529,7 +529,7 @@ impl TryFrom<RuntimeMetadataPrefixed> for Metadata {
             return Err(ConversionError::InvalidPrefix.into())
         }
         let meta = match metadata.1 {
-            RuntimeMetadata::V12(meta) => meta,
+            RuntimeMetadata::V13(meta) => meta,
             _ => return Err(ConversionError::InvalidVersion.into()),
         };
         let mut modules = HashMap::new();


### PR DESCRIPTION
There have been no releases of substrate dependencies on crates.io for a while, so this PR changes the substrate dependencies to `master` for now so we can sync up with the latest version.